### PR TITLE
Add Deepgram transcript conversion support

### DIFF
--- a/lib/convert.ex
+++ b/lib/convert.ex
@@ -2,14 +2,38 @@ defmodule BoldTranscriptsEx.Convert do
   require Logger
 
   alias BoldTranscriptsEx.Convert.Common
+  alias BoldTranscriptsEx.Convert.AssemblyAI
+  alias BoldTranscriptsEx.Convert.Deepgram
   alias BoldTranscriptsEx.Utils
 
+  @doc """
+  Converts a transcript from a specific service to Bold format.
+
+  ## Parameters
+
+  - `service`: The service that generated the transcript (e.g., `:assemblyai`, `:deepgram`)
+  - `transcript_data`: The JSON string or decoded map of the transcript data
+  - `opts`: Options for the conversion:
+    - `:language`: (required for Deepgram) The language code of the transcript (e.g., "en", "lt")
+    - Other service-specific options
+
+  ## Returns
+
+  - `{:ok, data}`: A tuple with `:ok` atom and the data in Bold Transcript format
+  - `{:error, reason}`: If the conversion fails or required options are missing
+  """
   def from(service, transcript_data, opts \\ [])
 
   def from(:assemblyai, transcript_json, opts) do
     transcript_json
     |> Utils.maybe_decode()
-    |> BoldTranscriptsEx.Convert.AssemblyAI.transcript_to_bold(opts)
+    |> AssemblyAI.transcript_to_bold(opts)
+  end
+
+  def from(:deepgram, transcript_json, opts) do
+    transcript_json
+    |> Utils.maybe_decode()
+    |> Deepgram.transcript_to_bold(opts)
   end
 
   def from(service, _transcript_data, _opts) do
@@ -21,7 +45,7 @@ defmodule BoldTranscriptsEx.Convert do
   def chapters_to_webvtt(:assemblyai, transcript_json, opts) do
     transcript_json
     |> Utils.maybe_decode()
-    |> BoldTranscriptsEx.Convert.AssemblyAI.chapters_to_webvtt(opts)
+    |> AssemblyAI.chapters_to_webvtt(opts)
   end
 
   def chapters_to_webvtt(service, _transcript_json, _opts) do

--- a/lib/convert/assembly_ai.ex
+++ b/lib/convert/assembly_ai.ex
@@ -26,17 +26,16 @@ defmodule BoldTranscriptsEx.Convert.AssemblyAI do
 
   """
   def transcript_to_bold(transcript, opts) do
-    paragraphs_data = Keyword.get(opts, :paragraphs, %{}) |> Utils.maybe_decode()
-    sentences_data = Keyword.get(opts, :sentences, %{}) |> Utils.maybe_decode()
+    paragraphs_data = Keyword.get(opts, :paragraphs, []) |> Utils.maybe_decode()
+    sentences_data = Keyword.get(opts, :sentences, []) |> Utils.maybe_decode()
     speakers = extract_speakers(transcript["utterances"])
 
     # Warning if paragraphs or sentences data is missing
     log_missing_data_warning(paragraphs_data, sentences_data)
 
     paragraphs =
-      if paragraphs_data != %{} and sentences_data != %{},
-        do:
-          merge_paragraphs_sentences(paragraphs_data["paragraphs"], sentences_data["sentences"]),
+      if paragraphs_data != [] and sentences_data != [],
+        do: merge_paragraphs_sentences(paragraphs_data, sentences_data),
         else: paragraphs_data
 
     merged_data = %{

--- a/lib/convert/deepgram.ex
+++ b/lib/convert/deepgram.ex
@@ -1,0 +1,88 @@
+defmodule BoldTranscriptsEx.Convert.Deepgram do
+  @moduledoc """
+  Handles conversion of Deepgram transcription files to Bold format.
+  """
+
+  require Logger
+
+  alias BoldTranscriptsEx.Utils
+
+  @doc """
+  Converts a Deepgram transcript to the Bold Transcript format.
+
+  ## Parameters
+
+  - `transcript`: The JSON string or decoded map of the transcript data from Deepgram.
+  - `opts`: Options for the conversion:
+    - `:language`: (required) The language code of the transcript (e.g., "en", "lt")
+
+  ## Returns
+
+  - `{:ok, merged_data}`: A tuple with `:ok` atom and the data in Bold Transcript format.
+  - `{:error, reason}`: If required options are missing.
+
+  ## Examples
+
+      iex> BoldTranscriptsEx.Convert.Deepgram.transcript_to_bold(transcript, language: "lt")
+      {:ok, %{"metadata" => metadata, "utterances" => utterances, "paragraphs" => paragraphs}}
+
+  """
+  def transcript_to_bold(transcript, opts \\ []) do
+    with {:ok, language} <- validate_language_option(opts) do
+      transcript = Utils.maybe_decode(transcript)
+      results = transcript["results"]["channels"] |> List.first()
+      utterances = results["alternatives"] |> List.first() |> Map.get("words", [])
+
+      speakers = extract_speakers(utterances)
+
+      merged_data = %{
+        "metadata" => extract_metadata(transcript, speakers, language),
+        "utterances" => extract_speech(utterances),
+        # Deepgram doesn't provide paragraph segmentation
+        "paragraphs" => []
+      }
+
+      {:ok, merged_data}
+    end
+  end
+
+  defp validate_language_option(opts) do
+    case Keyword.get(opts, :language) do
+      nil -> {:error, "Language option is required for Deepgram transcripts"}
+      language when is_binary(language) -> {:ok, language}
+      _ -> {:error, "Language must be a string"}
+    end
+  end
+
+  defp extract_metadata(data, speakers, language) do
+    %{
+      "duration" => data["metadata"]["duration"],
+      "language" => language,
+      # Deepgram doesn't provide source URL in transcript
+      "source_url" => nil,
+      "speakers" => speakers
+    }
+  end
+
+  defp extract_speech(words) do
+    words
+    |> Enum.map(fn word ->
+      %{
+        "start" => word["start"],
+        "end" => word["end"],
+        "confidence" => word["confidence"],
+        "speaker" => word["speaker"],
+        "text" => word["punctuated_word"] || word["word"]
+      }
+    end)
+  end
+
+  defp extract_speakers(words) when is_list(words) do
+    words
+    |> Enum.map(&Map.get(&1, "speaker"))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp extract_speakers(_), do: []
+end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -6,8 +6,8 @@ defmodule BoldTranscriptsEx.Utils do
     Jason.decode!(json)
   end
 
-  def maybe_decode(json) when is_map(json) do
-    json
+  def maybe_decode(data) when is_map(data) or is_list(data) do
+    data
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BoldTranscriptsEx.MixProject do
   def project do
     [
       app: :bold_transcripts_ex,
-      version: "0.3.4",
+      version: "0.4.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/bold_transcripts_ex_test.exs
+++ b/test/bold_transcripts_ex_test.exs
@@ -8,18 +8,121 @@ defmodule BoldTranscriptsExTest do
   defp load_json_from_file(path), do: File.read!(path)
 
   describe "AssemblyAI Transcripts" do
-    test "chapters to WebVTT" do
-      input = load_json_from_file("test/support/data/assembly_transcript_ig.json")
+    setup do
+      transcript = load_json_from_file("test/support/data/assembly_transcript_ig.json")
+      {:ok, transcript: transcript}
+    end
 
-      {:ok, vtt} = BoldTranscriptsEx.Convert.chapters_to_webvtt(:assemblyai, input)
+    test "converts transcript to Bold format", %{transcript: transcript} do
+      {:ok, result} = BoldTranscriptsEx.Convert.from(:assemblyai, transcript)
+
+      assert is_map(result)
+      assert Map.has_key?(result, "metadata")
+      assert Map.has_key?(result, "utterances")
+      assert Map.has_key?(result, "paragraphs")
+
+      # Check metadata structure
+      assert is_map(result["metadata"])
+      assert Map.has_key?(result["metadata"], "duration")
+      assert Map.has_key?(result["metadata"], "language")
+      assert Map.has_key?(result["metadata"], "source_url")
+      assert Map.has_key?(result["metadata"], "speakers")
+
+      # Check utterances structure
+      assert is_list(result["utterances"])
+
+      if length(result["utterances"]) > 0 do
+        utterance = List.first(result["utterances"])
+        assert Map.has_key?(utterance, "start")
+        assert Map.has_key?(utterance, "end")
+        assert Map.has_key?(utterance, "confidence")
+        assert Map.has_key?(utterance, "text")
+      end
+
+      # Check paragraphs structure
+      assert is_list(result["paragraphs"])
+
+      if length(result["paragraphs"]) > 0 do
+        paragraph = List.first(result["paragraphs"])
+        assert Map.has_key?(paragraph, "start")
+        assert Map.has_key?(paragraph, "end")
+        assert Map.has_key?(paragraph, "sentences")
+      end
+    end
+
+    test "chapters to WebVTT", %{transcript: transcript} do
+      {:ok, vtt} = BoldTranscriptsEx.Convert.chapters_to_webvtt(:assemblyai, transcript)
 
       assert String.starts_with?(vtt, "WEBVTT\n\n1\n00")
+      assert String.contains?(vtt, " --> ")
     end
 
     test "chapters to WebVTT without chapters" do
       input = load_json_from_file("test/support/data/assembly_transcript_ig_nil_chapters.json")
 
       assert {:error, _reason} = BoldTranscriptsEx.Convert.chapters_to_webvtt(:assemblyai, input)
+    end
+  end
+
+  describe "Deepgram Transcripts" do
+    setup do
+      transcript =
+        load_json_from_file("test/support/data/rolandas_transcript_deepgram_utt_smart_diar.json")
+
+      {:ok, transcript: transcript}
+    end
+
+    test "converts transcript to Bold format with language option", %{transcript: transcript} do
+      {:ok, result} = BoldTranscriptsEx.Convert.from(:deepgram, transcript, language: "lt")
+
+      assert is_map(result)
+      assert Map.has_key?(result, "metadata")
+      assert Map.has_key?(result, "utterances")
+      assert Map.has_key?(result, "paragraphs")
+
+      # Check metadata structure
+      assert is_map(result["metadata"])
+      assert Map.has_key?(result["metadata"], "duration")
+      assert result["metadata"]["language"] == "lt"
+      assert Map.has_key?(result["metadata"], "source_url")
+      assert Map.has_key?(result["metadata"], "speakers")
+
+      # Check utterances structure
+      assert is_list(result["utterances"])
+
+      if length(result["utterances"]) > 0 do
+        utterance = List.first(result["utterances"])
+        assert Map.has_key?(utterance, "start")
+        assert Map.has_key?(utterance, "end")
+        assert Map.has_key?(utterance, "confidence")
+        assert Map.has_key?(utterance, "text")
+        assert Map.has_key?(utterance, "speaker")
+      end
+
+      # Check paragraphs structure (should be empty for Deepgram)
+      assert result["paragraphs"] == []
+    end
+
+    test "fails without language option", %{transcript: transcript} do
+      assert {:error, "Language option is required for Deepgram transcripts"} =
+               BoldTranscriptsEx.Convert.from(:deepgram, transcript)
+    end
+
+    test "fails with invalid language option", %{transcript: transcript} do
+      assert {:error, "Language must be a string"} =
+               BoldTranscriptsEx.Convert.from(:deepgram, transcript, language: :lt)
+    end
+
+    test "verifies speaker diarization", %{transcript: transcript} do
+      {:ok, result} = BoldTranscriptsEx.Convert.from(:deepgram, transcript, language: "lt")
+
+      # Check that we have speakers identified
+      assert length(result["metadata"]["speakers"]) > 0
+
+      # Check that utterances have speaker labels
+      utterance = List.first(result["utterances"])
+      assert Map.has_key?(utterance, "speaker")
+      assert is_number(utterance["speaker"])
     end
   end
 end


### PR DESCRIPTION
This adds support for converting Deepgram transcripts to our Bold format. 

Key changes:
- New Deepgram conversion module
- Language code is required for Deepgram (e.g., "en", "lt")
- Comprehensive test coverage
- Matches existing AssemblyAI output format

Note: Unlike AssemblyAI, Deepgram doesn't provide paragraph segmentation, so the paragraphs field will be empty. All other fields (metadata, utterances, speakers) are fully supported.