### PR TITLE
feat: Add Mistral Voxtral transcript converter

### DIFF
--- a/lib/bold_transcripts_ex.ex
+++ b/lib/bold_transcripts_ex.ex
@@ -3,7 +3,7 @@ defmodule BoldTranscriptsEx do
   BoldTranscriptsEx is a library for working with transcripts in the Bold Video platform.
 
   It provides functionality for:
-  - Converting transcripts from various vendors (AssemblyAI, Deepgram) to Bold format
+  - Converting transcripts from various vendors (AssemblyAI, Deepgram, Speechmatics, Mistral) to Bold format
   - Generating WebVTT subtitles from Bold transcripts
   - Working with chapter markers in WebVTT format
   """
@@ -15,7 +15,7 @@ defmodule BoldTranscriptsEx do
 
   ## Parameters
 
-  - `service`: The service that generated the transcript (e.g., `:assemblyai`, `:deepgram`)
+  - `service`: The service that generated the transcript (e.g., `:assemblyai`, `:deepgram`, `:speechmatics`, `:mistral`)
   - `transcript_data`: The JSON string or decoded map of the transcript data
   - `opts`: Options for the conversion:
     - `:language`: (required for Deepgram) The language code of the transcript (e.g., "en", "lt")

--- a/lib/convert.ex
+++ b/lib/convert.ex
@@ -4,6 +4,7 @@ defmodule BoldTranscriptsEx.Convert do
   alias BoldTranscriptsEx.Convert.Common
   alias BoldTranscriptsEx.Convert.AssemblyAI
   alias BoldTranscriptsEx.Convert.Deepgram
+  alias BoldTranscriptsEx.Convert.Mistral
   alias BoldTranscriptsEx.Convert.Speechmatics
   alias BoldTranscriptsEx.Utils
 
@@ -41,6 +42,12 @@ defmodule BoldTranscriptsEx.Convert do
     transcript_json
     |> Utils.maybe_decode()
     |> Speechmatics.transcript_to_bold()
+  end
+
+  def from(:mistral, transcript_json, opts) do
+    transcript_json
+    |> Utils.maybe_decode()
+    |> Mistral.transcript_to_bold(opts)
   end
 
   def from(service, _transcript_data, _opts) do

--- a/lib/convert/language.ex
+++ b/lib/convert/language.ex
@@ -116,6 +116,35 @@ defmodule BoldTranscriptsEx.Convert.Language do
   end
 
   @doc """
+  Normalizes Mistral Voxtral language codes to internal format.
+
+  Since Voxtral doesn't include language in its response, this normalizes
+  user-provided language codes (typically base language like "en", "de").
+
+  ## Examples
+
+      iex> BoldTranscriptsEx.Convert.Language.normalize_mistral("en")
+      "en_us"
+
+      iex> BoldTranscriptsEx.Convert.Language.normalize_mistral("de")
+      "de_de"
+
+      iex> BoldTranscriptsEx.Convert.Language.normalize_mistral("es")
+      "es_es"
+
+      iex> BoldTranscriptsEx.Convert.Language.normalize_mistral(nil)
+      "en_us"
+  """
+  def normalize_mistral(nil), do: "en_us"
+  def normalize_mistral(""), do: "en_us"
+
+  def normalize_mistral(code) when is_binary(code) do
+    code
+    |> String.downcase()
+    |> add_default_region()
+  end
+
+  @doc """
   Generic language code normalizer with fallback to en_us.
 
   ## Examples

--- a/lib/convert/mistral.ex
+++ b/lib/convert/mistral.ex
@@ -1,0 +1,110 @@
+defmodule BoldTranscriptsEx.Convert.Mistral do
+  @moduledoc """
+  Handles conversion of Mistral Voxtral transcription files to Bold format.
+  """
+
+  require Logger
+
+  alias BoldTranscriptsEx.Convert.Language
+  alias BoldTranscriptsEx.Utils
+
+  @doc """
+  Converts a Mistral Voxtral transcript to the Bold Transcript format v2.
+
+  ## Parameters
+
+  - `transcript`: The JSON string or decoded map of the transcript data from Voxtral.
+  - `opts`: Options for the conversion:
+    - `:language`: The language code of the transcript (e.g., "en", "de"). Defaults to "en".
+
+  ## Returns
+
+  - `{:ok, merged_data}`: A tuple with `:ok` atom and the data in Bold Transcript format.
+
+  ## Examples
+
+      iex> transcript = ~s({"text": "Hello", "segments": [{"id": 0, "start": 0.0, "end": 1.0, "text": "Hello", "speaker": "speaker_0", "words": [{"word": "Hello", "start": 0.0, "end": 1.0}]}]})
+      iex> BoldTranscriptsEx.Convert.Mistral.transcript_to_bold(transcript)
+      {:ok, %{"metadata" => %{"version" => "2.0", "duration" => 1.0, "language" => "en_us", "source_url" => "", "source_vendor" => "mistral", "source_model" => "", "source_version" => "", "transcription_date" => nil, "speakers" => %{"A" => nil}}, "utterances" => [%{"start" => 0.0, "end" => 1.0, "text" => "Hello", "speaker" => "A", "confidence" => 1.0, "words" => [%{"word" => "Hello", "start" => 0.0, "end" => 1.0, "confidence" => 1.0}]}]}}
+
+  """
+  def transcript_to_bold(transcript, opts \\ []) do
+    transcript = Utils.maybe_decode(transcript)
+    segments = transcript["segments"] || []
+    speaker_map = build_speaker_map(segments)
+    utterances = build_utterances(segments, speaker_map)
+    metadata = build_metadata(segments, speaker_map, opts)
+
+    {:ok, %{"metadata" => metadata, "utterances" => utterances}}
+  end
+
+  defp build_metadata(segments, speaker_map, opts) do
+    language = Keyword.get(opts, :language)
+    last_segment = List.last(segments)
+    duration = if last_segment, do: ensure_float(last_segment["end"]), else: 0.0
+
+    speakers =
+      speaker_map
+      |> Map.values()
+      |> Enum.sort()
+      |> Enum.into(%{}, fn letter -> {letter, nil} end)
+
+    %{
+      "version" => "2.0",
+      "duration" => duration,
+      "language" => Language.normalize_mistral(language),
+      "source_url" => "",
+      "source_vendor" => "mistral",
+      "source_model" => "",
+      "source_version" => "",
+      "transcription_date" => nil,
+      "speakers" => speakers
+    }
+  end
+
+  defp build_speaker_map(segments) do
+    segments
+    |> Enum.map(&Map.get(&1, "speaker"))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.with_index()
+    |> Enum.into(%{}, fn {speaker_label, index} ->
+      {speaker_label, <<65 + index>>}
+    end)
+  end
+
+  defp build_utterances(segments, speaker_map) do
+    Enum.map(segments, fn segment ->
+      words = build_words(segment["words"])
+
+      %{
+        "start" => ensure_float(segment["start"]),
+        "end" => ensure_float(segment["end"]),
+        "text" => segment["text"],
+        "speaker" => Map.get(speaker_map, segment["speaker"]),
+        "confidence" => 1.0,
+        "words" => words
+      }
+    end)
+  end
+
+  defp build_words(nil), do: []
+
+  defp build_words(words) when is_list(words) do
+    Enum.map(words, fn word ->
+      %{
+        "word" => word["word"],
+        "start" => ensure_float(word["start"]),
+        "end" => ensure_float(word["end"]),
+        "confidence" => word["confidence"] || 1.0
+      }
+    end)
+  end
+
+  defp build_words(_), do: []
+
+  defp ensure_float(value) when is_float(value), do: value
+  defp ensure_float(value) when is_integer(value), do: value * 1.0
+  defp ensure_float(_), do: 0.0
+end

--- a/lib/webvtt.ex
+++ b/lib/webvtt.ex
@@ -211,6 +211,9 @@ defmodule BoldTranscriptsEx.WebVTT do
 
   defp extract_speaker_names(_), do: %{}
 
+  defp format_subtitle_time(seconds) when is_integer(seconds),
+    do: format_subtitle_time(seconds * 1.0)
+
   defp format_subtitle_time(seconds) when is_float(seconds) do
     total_milliseconds = trunc(seconds * 1000)
     hours = div(total_milliseconds, 3_600_000)

--- a/test/convert/mistral_test.exs
+++ b/test/convert/mistral_test.exs
@@ -1,0 +1,253 @@
+defmodule BoldTranscriptsEx.Convert.MistralTest do
+  use ExUnit.Case
+
+  alias BoldTranscriptsEx.Convert.Mistral
+
+  @transcript_file "test/support/data/mistral_bold-demo.json"
+
+  describe "transcript_to_bold/2" do
+    test "converts multi-speaker transcript" do
+      transcript = File.read!(@transcript_file)
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      # Assert metadata
+      assert result["metadata"]["version"] == "2.0"
+      assert result["metadata"]["duration"] == 42.24
+      assert result["metadata"]["language"] == "en_us"
+      assert result["metadata"]["source_vendor"] == "mistral"
+      assert result["metadata"]["source_model"] == ""
+      assert result["metadata"]["source_version"] == ""
+      assert result["metadata"]["transcription_date"] == nil
+      assert result["metadata"]["speakers"] == %{"A" => nil, "B" => nil}
+
+      # Assert utterances
+      assert length(result["utterances"]) == 10
+
+      # First utterance (speaker_0 -> A)
+      [utterance | _] = result["utterances"]
+      assert utterance["start"] == 0.0
+      assert utterance["end"] == 3.84
+      assert utterance["speaker"] == "A"
+      assert utterance["text"] == "Welcome to the Bold Video demo."
+      assert utterance["confidence"] == 1.0
+
+      # Check words
+      assert length(utterance["words"]) == 6
+      [first_word | _] = utterance["words"]
+      assert first_word["word"] == "Welcome"
+      assert first_word["start"] == 0.0
+      assert first_word["end"] == 0.48
+      assert first_word["confidence"] == 1.0
+
+      # Third utterance (speaker_1 -> B)
+      third = Enum.at(result["utterances"], 2)
+      assert third["speaker"] == "B"
+      assert third["text"] == "That sounds great."
+    end
+
+    test "handles single-speaker transcript" do
+      transcript = %{
+        "text" => "Hello world.",
+        "segments" => [
+          %{
+            "id" => 0,
+            "start" => 0.0,
+            "end" => 2.0,
+            "text" => "Hello world.",
+            "speaker" => "speaker_0",
+            "words" => [
+              %{"word" => "Hello", "start" => 0.0, "end" => 0.8},
+              %{"word" => "world.", "start" => 1.0, "end" => 2.0}
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert result["metadata"]["speakers"] == %{"A" => nil}
+      assert length(result["utterances"]) == 1
+      assert hd(result["utterances"])["speaker"] == "A"
+    end
+
+    test "handles missing words array" do
+      transcript = %{
+        "text" => "Hello.",
+        "segments" => [
+          %{
+            "id" => 0,
+            "start" => 0.0,
+            "end" => 1.0,
+            "text" => "Hello.",
+            "speaker" => "speaker_0"
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert length(result["utterances"]) == 1
+      utterance = hd(result["utterances"])
+      assert utterance["words"] == []
+      assert utterance["text"] == "Hello."
+    end
+
+    test "handles null words array" do
+      transcript = %{
+        "text" => "Hello.",
+        "segments" => [
+          %{
+            "id" => 0,
+            "start" => 0.0,
+            "end" => 1.0,
+            "text" => "Hello.",
+            "speaker" => "speaker_0",
+            "words" => nil
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      utterance = hd(result["utterances"])
+      assert utterance["words"] == []
+    end
+
+    test "coerces integer timestamps to floats" do
+      transcript = %{
+        "text" => "Hello world.",
+        "segments" => [
+          %{
+            "id" => 0,
+            "start" => 0,
+            "end" => 4,
+            "text" => "Hello world.",
+            "speaker" => "speaker_0",
+            "words" => [
+              %{"word" => "Hello", "start" => 0, "end" => 2},
+              %{"word" => "world.", "start" => 2, "end" => 4}
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      utterance = hd(result["utterances"])
+      assert is_float(utterance["start"])
+      assert is_float(utterance["end"])
+      assert utterance["start"] == 0.0
+      assert utterance["end"] == 4.0
+
+      # Check duration is also float
+      assert is_float(result["metadata"]["duration"])
+      assert result["metadata"]["duration"] == 4.0
+
+      # Check word timestamps
+      first_word = hd(utterance["words"])
+      assert is_float(first_word["start"])
+      assert is_float(first_word["end"])
+    end
+
+    test "defaults confidence to 1.0 when absent" do
+      transcript = %{
+        "text" => "Hello.",
+        "segments" => [
+          %{
+            "id" => 0,
+            "start" => 0.0,
+            "end" => 1.0,
+            "text" => "Hello.",
+            "speaker" => "speaker_0",
+            "words" => [
+              %{"word" => "Hello.", "start" => 0.0, "end" => 1.0}
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      utterance = hd(result["utterances"])
+      assert utterance["confidence"] == 1.0
+
+      word = hd(utterance["words"])
+      assert word["confidence"] == 1.0
+    end
+
+    test "handles no speaker key (diarize=false)" do
+      transcript = %{
+        "text" => "Hello.",
+        "segments" => [
+          %{
+            "id" => 0,
+            "start" => 0.0,
+            "end" => 1.0,
+            "text" => "Hello.",
+            "words" => [
+              %{"word" => "Hello.", "start" => 0.0, "end" => 1.0}
+            ]
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert result["metadata"]["speakers"] == %{}
+      utterance = hd(result["utterances"])
+      assert utterance["speaker"] == nil
+    end
+
+    test "handles empty segments" do
+      transcript = %{"text" => "", "segments" => []}
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert result["metadata"]["duration"] == 0.0
+      assert result["metadata"]["speakers"] == %{}
+      assert result["utterances"] == []
+    end
+
+    test "accepts language option" do
+      transcript = %{
+        "text" => "Hallo.",
+        "segments" => [
+          %{
+            "id" => 0,
+            "start" => 0.0,
+            "end" => 1.0,
+            "text" => "Hallo.",
+            "speaker" => "speaker_0",
+            "words" => [%{"word" => "Hallo.", "start" => 0.0, "end" => 1.0}]
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript, language: "de")
+
+      assert result["metadata"]["language"] == "de_de"
+    end
+  end
+
+  describe "integration" do
+    test "works through public API dispatch" do
+      transcript = File.read!(@transcript_file)
+
+      {:ok, result} = BoldTranscriptsEx.convert(:mistral, transcript)
+
+      assert result["metadata"]["source_vendor"] == "mistral"
+      assert length(result["utterances"]) == 10
+    end
+
+    test "output produces valid WebVTT" do
+      transcript = File.read!(@transcript_file)
+
+      {:ok, bold} = BoldTranscriptsEx.convert(:mistral, transcript)
+      webvtt = BoldTranscriptsEx.generate_subtitles(bold)
+
+      assert String.starts_with?(webvtt, "WEBVTT")
+      assert String.contains?(webvtt, "-->")
+    end
+  end
+end

--- a/test/support/data/mistral_bold-demo.json
+++ b/test/support/data/mistral_bold-demo.json
@@ -1,0 +1,170 @@
+{
+  "text": "Welcome to the Bold Video demo. Today we'll be discussing our new transcription features. That sounds great. I'm really excited to show what we've built. So let's start with the basics. Our platform now supports multiple speech to text vendors. That's right. And the best part is that all transcripts get converted to a unified format. Which makes it really easy to switch between providers. Exactly. Users don't have to worry about vendor lock-in anymore.",
+  "segments": [
+    {
+      "id": 0,
+      "start": 0,
+      "end": 3.84,
+      "text": "Welcome to the Bold Video demo.",
+      "speaker": "speaker_0",
+      "words": [
+        {"word": "Welcome", "start": 0, "end": 0.48},
+        {"word": "to", "start": 0.52, "end": 0.64},
+        {"word": "the", "start": 0.68, "end": 0.8},
+        {"word": "Bold", "start": 0.84, "end": 1.12},
+        {"word": "Video", "start": 1.16, "end": 1.52},
+        {"word": "demo.", "start": 1.56, "end": 3.84}
+      ]
+    },
+    {
+      "id": 1,
+      "start": 4.2,
+      "end": 8.96,
+      "text": "Today we'll be discussing our new transcription features.",
+      "speaker": "speaker_0",
+      "words": [
+        {"word": "Today", "start": 4.2, "end": 4.56},
+        {"word": "we'll", "start": 4.6, "end": 4.84},
+        {"word": "be", "start": 4.88, "end": 5.0},
+        {"word": "discussing", "start": 5.04, "end": 5.68},
+        {"word": "our", "start": 5.72, "end": 5.92},
+        {"word": "new", "start": 5.96, "end": 6.16},
+        {"word": "transcription", "start": 6.2, "end": 7.04},
+        {"word": "features.", "start": 7.08, "end": 8.96}
+      ]
+    },
+    {
+      "id": 2,
+      "start": 9.52,
+      "end": 11.2,
+      "text": "That sounds great.",
+      "speaker": "speaker_1",
+      "words": [
+        {"word": "That", "start": 9.52, "end": 9.76},
+        {"word": "sounds", "start": 9.8, "end": 10.24},
+        {"word": "great.", "start": 10.28, "end": 11.2}
+      ]
+    },
+    {
+      "id": 3,
+      "start": 11.68,
+      "end": 15.36,
+      "text": "I'm really excited to show what we've built.",
+      "speaker": "speaker_1",
+      "words": [
+        {"word": "I'm", "start": 11.68, "end": 11.92},
+        {"word": "really", "start": 11.96, "end": 12.32},
+        {"word": "excited", "start": 12.36, "end": 12.88},
+        {"word": "to", "start": 12.92, "end": 13.04},
+        {"word": "show", "start": 13.08, "end": 13.36},
+        {"word": "what", "start": 13.4, "end": 13.6},
+        {"word": "we've", "start": 13.64, "end": 13.92},
+        {"word": "built.", "start": 13.96, "end": 15.36}
+      ]
+    },
+    {
+      "id": 4,
+      "start": 16.0,
+      "end": 18.72,
+      "text": "So let's start with the basics.",
+      "speaker": "speaker_0",
+      "words": [
+        {"word": "So", "start": 16.0, "end": 16.24},
+        {"word": "let's", "start": 16.28, "end": 16.56},
+        {"word": "start", "start": 16.6, "end": 16.96},
+        {"word": "with", "start": 17.0, "end": 17.2},
+        {"word": "the", "start": 17.24, "end": 17.36},
+        {"word": "basics.", "start": 17.4, "end": 18.72}
+      ]
+    },
+    {
+      "id": 5,
+      "start": 19.2,
+      "end": 24.48,
+      "text": "Our platform now supports multiple speech to text vendors.",
+      "speaker": "speaker_0",
+      "words": [
+        {"word": "Our", "start": 19.2, "end": 19.44},
+        {"word": "platform", "start": 19.48, "end": 20.08},
+        {"word": "now", "start": 20.12, "end": 20.4},
+        {"word": "supports", "start": 20.44, "end": 21.04},
+        {"word": "multiple", "start": 21.08, "end": 21.6},
+        {"word": "speech", "start": 21.64, "end": 22.0},
+        {"word": "to", "start": 22.04, "end": 22.16},
+        {"word": "text", "start": 22.2, "end": 22.56},
+        {"word": "vendors.", "start": 22.6, "end": 24.48}
+      ]
+    },
+    {
+      "id": 6,
+      "start": 25.0,
+      "end": 26.08,
+      "text": "That's right.",
+      "speaker": "speaker_1",
+      "words": [
+        {"word": "That's", "start": 25.0, "end": 25.36},
+        {"word": "right.", "start": 25.4, "end": 26.08}
+      ]
+    },
+    {
+      "id": 7,
+      "start": 26.56,
+      "end": 32.16,
+      "text": "And the best part is that all transcripts get converted to a unified format.",
+      "speaker": "speaker_1",
+      "words": [
+        {"word": "And", "start": 26.56, "end": 26.8},
+        {"word": "the", "start": 26.84, "end": 26.96},
+        {"word": "best", "start": 27.0, "end": 27.28},
+        {"word": "part", "start": 27.32, "end": 27.6},
+        {"word": "is", "start": 27.64, "end": 27.76},
+        {"word": "that", "start": 27.8, "end": 28.0},
+        {"word": "all", "start": 28.04, "end": 28.24},
+        {"word": "transcripts", "start": 28.28, "end": 29.04},
+        {"word": "get", "start": 29.08, "end": 29.28},
+        {"word": "converted", "start": 29.32, "end": 29.92},
+        {"word": "to", "start": 29.96, "end": 30.08},
+        {"word": "a", "start": 30.12, "end": 30.2},
+        {"word": "unified", "start": 30.24, "end": 30.72},
+        {"word": "format.", "start": 30.76, "end": 32.16}
+      ]
+    },
+    {
+      "id": 8,
+      "start": 32.8,
+      "end": 36.48,
+      "text": "Which makes it really easy to switch between providers.",
+      "speaker": "speaker_0",
+      "words": [
+        {"word": "Which", "start": 32.8, "end": 33.04},
+        {"word": "makes", "start": 33.08, "end": 33.44},
+        {"word": "it", "start": 33.48, "end": 33.6},
+        {"word": "really", "start": 33.64, "end": 34.0},
+        {"word": "easy", "start": 34.04, "end": 34.4},
+        {"word": "to", "start": 34.44, "end": 34.56},
+        {"word": "switch", "start": 34.6, "end": 34.96},
+        {"word": "between", "start": 35.0, "end": 35.36},
+        {"word": "providers.", "start": 35.4, "end": 36.48}
+      ]
+    },
+    {
+      "id": 9,
+      "start": 37.0,
+      "end": 42.24,
+      "text": "Exactly. Users don't have to worry about vendor lock-in anymore.",
+      "speaker": "speaker_1",
+      "words": [
+        {"word": "Exactly.", "start": 37.0, "end": 37.68},
+        {"word": "Users", "start": 37.84, "end": 38.24},
+        {"word": "don't", "start": 38.28, "end": 38.56},
+        {"word": "have", "start": 38.6, "end": 38.8},
+        {"word": "to", "start": 38.84, "end": 38.96},
+        {"word": "worry", "start": 39.0, "end": 39.36},
+        {"word": "about", "start": 39.4, "end": 39.68},
+        {"word": "vendor", "start": 39.72, "end": 40.08},
+        {"word": "lock-in", "start": 40.12, "end": 40.64},
+        {"word": "anymore.", "start": 40.68, "end": 42.24}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `BoldTranscriptsEx.Convert.Mistral` module that converts Voxtral speech-to-text JSON to Bold Transcript v2.0 format
- Register `:mistral` in the `Convert` dispatcher so `BoldTranscriptsEx.convert(:mistral, json, opts)` works
- Fix latent bug in `WebVTT.format_subtitle_time/1` that crashed on integer timestamps

## What's New

**New files:**
- `lib/convert/mistral.ex` — Voxtral → Bold v2 converter
- `test/convert/mistral_test.exs` — 11 tests covering happy path + edge cases
- `test/support/data/mistral_bold-demo.json` — Multi-speaker test fixture

**Modified files:**
- `lib/convert.ex` — Added `:mistral` dispatch clause
- `lib/convert/language.ex` — Added `normalize_mistral/1` with `add_default_region/1`
- `lib/webvtt.ex` — Added integer guard to `format_subtitle_time/1` (defense in depth)
- `lib/bold_transcripts_ex.ex` — Updated docs to mention all 4 vendors

## Key Design Decisions

- **V2 only** — No v1 support needed (matches Speechmatics pattern)
- **Language from opts** — Voxtral JSON has no language field; accept `:language` option, default `"en"` → `"en_us"`
- **Duration computed** — Derived from last segment's end time (Voxtral doesn't provide it)
- **Float coercion** — All timestamps coerced via `ensure_float/1` to prevent WebVTT crash on integer `0`
- **Speaker sort** — `speaker_N` labels sorted with `Enum.sort/1` before mapping to A/B/C

## Test Plan

- [x] Multi-speaker transcript conversion (fixture-based)
- [x] Single-speaker transcript
- [x] Missing words array
- [x] Null words array
- [x] Integer timestamp coercion
- [x] Confidence defaults to 1.0
- [x] No speaker key (diarize=false)
- [x] Empty segments
- [x] Language option
- [x] Public API dispatch integration test
- [x] WebVTT round-trip test (convert → generate_subtitles)

All 92 tests pass (29 doctests + 63 tests, 0 failures).

Closes BOLD-1251