### PR TITLE
fix: Handle real Mistral Voxtral API formats

### DIFF
--- a/lib/convert/mistral.ex
+++ b/lib/convert/mistral.ex
@@ -1,12 +1,23 @@
 defmodule BoldTranscriptsEx.Convert.Mistral do
   @moduledoc """
   Handles conversion of Mistral Voxtral transcription files to Bold format.
+
+  Supports three segment formats from the Voxtral API:
+
+  - **Legacy**: Segments have a nested `"words"` array and a `"speaker"` key.
+  - **Diarized**: Segments are sentence-level with `"speaker_id"` but no `"words"`.
+  - **Word-level**: Segments are individual words with no speaker info and no `"words"`.
   """
 
   require Logger
 
   alias BoldTranscriptsEx.Convert.Language
   alias BoldTranscriptsEx.Utils
+
+  # Maximum words per utterance when grouping word-level segments
+  @max_words_per_utterance 30
+  # Pause threshold (seconds) for splitting word-level segments into utterances
+  @pause_threshold 1.0
 
   @doc """
   Converts a Mistral Voxtral transcript to the Bold Transcript format v2.
@@ -31,11 +42,23 @@ defmodule BoldTranscriptsEx.Convert.Mistral do
   def transcript_to_bold(transcript, opts \\ []) do
     transcript = Utils.maybe_decode(transcript)
     segments = transcript["segments"] || []
-    speaker_map = build_speaker_map(segments)
-    utterances = build_utterances(segments, speaker_map)
+    format = detect_format(segments)
+    speaker_map = build_speaker_map(segments, format)
+    utterances = build_utterances(segments, speaker_map, format)
     metadata = build_metadata(segments, speaker_map, opts)
 
     {:ok, %{"metadata" => metadata, "utterances" => utterances}}
+  end
+
+  defp detect_format([]), do: :legacy
+
+  defp detect_format([first | _]) do
+    cond do
+      Map.has_key?(first, "words") -> :legacy
+      Map.has_key?(first, "speaker") -> :legacy
+      Map.has_key?(first, "speaker_id") -> :diarized
+      true -> :word_level
+    end
   end
 
   defp build_metadata(segments, speaker_map, opts) do
@@ -62,7 +85,19 @@ defmodule BoldTranscriptsEx.Convert.Mistral do
     }
   end
 
-  defp build_speaker_map(segments) do
+  defp build_speaker_map(segments, :diarized) do
+    segments
+    |> Enum.map(&Map.get(&1, "speaker_id"))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.with_index()
+    |> Enum.into(%{}, fn {speaker_label, index} ->
+      {speaker_label, <<65 + index>>}
+    end)
+  end
+
+  defp build_speaker_map(segments, _format) do
     segments
     |> Enum.map(&Map.get(&1, "speaker"))
     |> Enum.reject(&is_nil/1)
@@ -74,20 +109,106 @@ defmodule BoldTranscriptsEx.Convert.Mistral do
     end)
   end
 
-  defp build_utterances(segments, speaker_map) do
+  defp build_utterances(segments, speaker_map, :legacy) do
     Enum.map(segments, fn segment ->
       words = build_words(segment["words"])
 
       %{
         "start" => ensure_float(segment["start"]),
         "end" => ensure_float(segment["end"]),
-        "text" => segment["text"],
+        "text" => trim_text(segment["text"]),
         "speaker" => Map.get(speaker_map, segment["speaker"]),
         "confidence" => 1.0,
         "words" => words
       }
     end)
   end
+
+  defp build_utterances(segments, speaker_map, :diarized) do
+    Enum.map(segments, fn segment ->
+      text = trim_text(segment["text"])
+
+      %{
+        "start" => ensure_float(segment["start"]),
+        "end" => ensure_float(segment["end"]),
+        "text" => text,
+        "speaker" => Map.get(speaker_map, segment["speaker_id"]),
+        "confidence" => 1.0,
+        "words" => [
+          %{
+            "word" => text,
+            "start" => ensure_float(segment["start"]),
+            "end" => ensure_float(segment["end"]),
+            "confidence" => 1.0
+          }
+        ]
+      }
+    end)
+  end
+
+  defp build_utterances(segments, _speaker_map, :word_level) do
+    segments
+    |> group_word_segments()
+    |> Enum.map(fn group ->
+      first = List.first(group)
+      last = List.last(group)
+      text = group |> Enum.map_join(" ", &trim_text(&1["text"])) |> String.trim()
+
+      words =
+        Enum.map(group, fn seg ->
+          %{
+            "word" => trim_text(seg["text"]),
+            "start" => ensure_float(seg["start"]),
+            "end" => ensure_float(seg["end"]),
+            "confidence" => 1.0
+          }
+        end)
+
+      %{
+        "start" => ensure_float(first["start"]),
+        "end" => ensure_float(last["end"]),
+        "text" => text,
+        "speaker" => nil,
+        "confidence" => 1.0,
+        "words" => words
+      }
+    end)
+  end
+
+  defp group_word_segments(segments) do
+    {groups, current} =
+      segments
+      |> Enum.with_index()
+      |> Enum.reduce({[], []}, fn {segment, index}, {groups, current} ->
+        current = current ++ [segment]
+        next_segment = Enum.at(segments, index + 1)
+
+        should_split =
+          ends_with_sentence_punctuation?(segment["text"]) ||
+            (next_segment != nil &&
+               ensure_float(next_segment["start"]) - ensure_float(segment["end"]) >
+                 @pause_threshold) ||
+            length(current) >= @max_words_per_utterance
+
+        if should_split do
+          {groups ++ [current], []}
+        else
+          {groups, current}
+        end
+      end)
+
+    if current == [], do: groups, else: groups ++ [current]
+  end
+
+  defp ends_with_sentence_punctuation?(text) when is_binary(text) do
+    text = String.trim(text)
+    String.ends_with?(text, ".") || String.ends_with?(text, "?") || String.ends_with?(text, "!")
+  end
+
+  defp ends_with_sentence_punctuation?(_), do: false
+
+  defp trim_text(text) when is_binary(text), do: String.trim(text)
+  defp trim_text(text), do: text
 
   defp build_words(nil), do: []
 

--- a/test/convert/mistral_test.exs
+++ b/test/convert/mistral_test.exs
@@ -230,6 +230,222 @@ defmodule BoldTranscriptsEx.Convert.MistralTest do
     end
   end
 
+  describe "diarized format (speaker_id, no words array)" do
+    @diarized_file "test/support/data/mistral_voxtral-diarized.json"
+
+    test "converts diarized transcript with speaker_id" do
+      transcript = File.read!(@diarized_file)
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert result["metadata"]["version"] == "2.0"
+      assert result["metadata"]["source_vendor"] == "mistral"
+      assert result["metadata"]["speakers"] == %{"A" => nil}
+
+      # Should have many utterances (one per segment)
+      assert length(result["utterances"]) > 0
+
+      # First utterance
+      first = hd(result["utterances"])
+      assert first["speaker"] == "A"
+      assert first["start"] == 10.2
+      assert first["end"] == 11.9
+      assert first["text"] == "I bet you thought we were done, right?"
+      assert first["confidence"] == 1.0
+
+      # Should have synthetic words for WebVTT generation
+      assert length(first["words"]) == 1
+      word = hd(first["words"])
+      assert word["word"] == "I bet you thought we were done, right?"
+      assert word["start"] == 10.2
+      assert word["end"] == 11.9
+    end
+
+    test "diarized format produces valid WebVTT" do
+      transcript = File.read!(@diarized_file)
+
+      {:ok, bold} = Mistral.transcript_to_bold(transcript)
+      webvtt = BoldTranscriptsEx.generate_subtitles(bold)
+
+      assert String.starts_with?(webvtt, "WEBVTT")
+      assert String.contains?(webvtt, "-->")
+      # Should have actual cues, not just the header
+      assert length(String.split(webvtt, "-->")) > 2
+    end
+
+    test "handles speaker_id mapping" do
+      transcript = %{
+        "text" => "Hello. Hi there.",
+        "segments" => [
+          %{
+            "text" => " Hello.",
+            "start" => 0.0,
+            "end" => 1.0,
+            "type" => "transcription_segment",
+            "speaker_id" => "speaker_1"
+          },
+          %{
+            "text" => " Hi there.",
+            "start" => 1.5,
+            "end" => 2.5,
+            "type" => "transcription_segment",
+            "speaker_id" => "speaker_2"
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert result["metadata"]["speakers"] == %{"A" => nil, "B" => nil}
+      assert Enum.at(result["utterances"], 0)["speaker"] == "A"
+      assert Enum.at(result["utterances"], 1)["speaker"] == "B"
+    end
+
+    test "trims leading whitespace from text" do
+      transcript = %{
+        "text" => "Hello.",
+        "segments" => [
+          %{
+            "text" => " Hello.",
+            "start" => 0.0,
+            "end" => 1.0,
+            "type" => "transcription_segment",
+            "speaker_id" => "speaker_1"
+          }
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      utterance = hd(result["utterances"])
+      assert utterance["text"] == "Hello."
+      assert hd(utterance["words"])["word"] == "Hello."
+    end
+  end
+
+  describe "word-level format (no speaker_id, no words array)" do
+    @word_level_file "test/support/data/mistral_voxtral-word-level.json"
+
+    test "converts word-level transcript" do
+      transcript = File.read!(@word_level_file)
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert result["metadata"]["version"] == "2.0"
+      assert result["metadata"]["source_vendor"] == "mistral"
+      assert result["metadata"]["speakers"] == %{}
+
+      # Should have grouped words into utterances
+      assert length(result["utterances"]) > 0
+
+      # All utterances should have nil speaker
+      Enum.each(result["utterances"], fn u ->
+        assert u["speaker"] == nil
+      end)
+
+      # All utterances should have non-empty words
+      Enum.each(result["utterances"], fn u ->
+        assert length(u["words"]) > 0
+      end)
+    end
+
+    test "groups words by sentence punctuation" do
+      transcript = %{
+        "text" => "Hello world. How are you?",
+        "segments" => [
+          %{"text" => " Hello", "start" => 0.0, "end" => 0.3, "type" => "transcription_segment"},
+          %{"text" => " world.", "start" => 0.3, "end" => 0.6, "type" => "transcription_segment"},
+          %{"text" => " How", "start" => 0.7, "end" => 0.9, "type" => "transcription_segment"},
+          %{"text" => " are", "start" => 0.9, "end" => 1.0, "type" => "transcription_segment"},
+          %{"text" => " you?", "start" => 1.0, "end" => 1.3, "type" => "transcription_segment"}
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert length(result["utterances"]) == 2
+
+      first = Enum.at(result["utterances"], 0)
+      assert first["text"] == "Hello world."
+      assert first["start"] == 0.0
+      assert first["end"] == 0.6
+      assert length(first["words"]) == 2
+
+      second = Enum.at(result["utterances"], 1)
+      assert second["text"] == "How are you?"
+      assert second["start"] == 0.7
+      assert second["end"] == 1.3
+      assert length(second["words"]) == 3
+    end
+
+    test "groups words by pause gap" do
+      transcript = %{
+        "text" => "Hello world How are you",
+        "segments" => [
+          %{"text" => " Hello", "start" => 0.0, "end" => 0.3, "type" => "transcription_segment"},
+          %{"text" => " world", "start" => 0.3, "end" => 0.6, "type" => "transcription_segment"},
+          # 2 second gap
+          %{"text" => " How", "start" => 2.6, "end" => 2.9, "type" => "transcription_segment"},
+          %{"text" => " are", "start" => 2.9, "end" => 3.0, "type" => "transcription_segment"},
+          %{"text" => " you", "start" => 3.0, "end" => 3.3, "type" => "transcription_segment"}
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      assert length(result["utterances"]) == 2
+
+      first = Enum.at(result["utterances"], 0)
+      assert first["text"] == "Hello world"
+
+      second = Enum.at(result["utterances"], 1)
+      assert second["text"] == "How are you"
+    end
+
+    test "word-level format produces valid WebVTT" do
+      transcript = File.read!(@word_level_file)
+
+      {:ok, bold} = Mistral.transcript_to_bold(transcript)
+      webvtt = BoldTranscriptsEx.generate_subtitles(bold)
+
+      assert String.starts_with?(webvtt, "WEBVTT")
+      assert String.contains?(webvtt, "-->")
+      # Should have actual cues, not just the header
+      assert length(String.split(webvtt, "-->")) > 2
+    end
+
+    test "trims leading whitespace from words" do
+      transcript = %{
+        "text" => "Hi.",
+        "segments" => [
+          %{"text" => " Hi.", "start" => 0.0, "end" => 0.5, "type" => "transcription_segment"}
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      utterance = hd(result["utterances"])
+      assert utterance["text"] == "Hi."
+      assert hd(utterance["words"])["word"] == "Hi."
+    end
+
+    test "coerces integer timestamps in word-level format" do
+      transcript = %{
+        "text" => "Hi.",
+        "segments" => [
+          %{"text" => " Hi.", "start" => 0, "end" => 1, "type" => "transcription_segment"}
+        ]
+      }
+
+      {:ok, result} = Mistral.transcript_to_bold(transcript)
+
+      utterance = hd(result["utterances"])
+      assert is_float(utterance["start"])
+      assert is_float(utterance["end"])
+      assert is_float(hd(utterance["words"])["start"])
+    end
+  end
+
   describe "integration" do
     test "works through public API dispatch" do
       transcript = File.read!(@transcript_file)

--- a/test/support/data/mistral_voxtral-diarized.json
+++ b/test/support/data/mistral_voxtral-diarized.json
@@ -1,0 +1,1693 @@
+{
+  "model": "voxtral-mini-latest",
+  "text": "I bet you thought we were done, right? Like five pillars in a single source of truth. We've got five videos covering those pillars. We're good, Jonna. I got it. I know we are so close, but there is one final topic to cover, which is bringing all five of these pillars in your single source of truth together. Because the real power of this system is not each individual pillar. It's how these pillars fit and automatically sync together to create one cohesive single source of truth that runs the day to day of your business. So I want to take some time here just to dive a little bit deeper into how all of these different pillars work and play together and give you a tactical example so that you can understand firsthand how having this new system running within your business with all five pillars firing on all cylinders is going to be absolutely transformative. So if you will bear with me, we have one final topic to cover together. And then I am going to walk you through building out and finalizing the tangible deliverable of all of this information, which is going to be the finished outline of your single source of truth. So let's dive into it by starting with a tangible, a tactical example about how each of these core pillars in the single source of truth work together seamlessly in the background to create one maximally efficient team for you and for your business. The example that I want to use is client onboarding, because traditionally client onboarding is a mess in just about every business I've ever looked at or worked with. Why? Because it's so complicated. It requires so many different steps from so many different people that need to happen in really tight order back to back to back as quickly as possible. And any mistake pisses off your client and really incurs a very real risk that they might leave. Right. Like mistakes in client onboarding totally destroy client trust and client experience. And we know how much that costs us in the form of lower client lifetime value. So client onboarding is a great one because it's super hard to do well and it's super high stakes. So let's talk about how we could use our single source of truth once it's all built out to make client onboarding not just fast, not just frictionless, but actually fully automated. I mentioned that when I ran a digital marketing agency, we were onboarding two to four clients a day, and that entire process happened on autopilot, meaning I did not look at it once. I trusted the system to run this incredibly complicated multi-step process without me. What did that look like? It looked something like this. So we had a new client. Our closer hopped on a call with them and closed them. Fantastic. As soon as that client hopped off the call, the very next step would be for my closer to fill out what we called a client onboarding form. You've got one form with all of the critical information about that client and everything that the back end team needs in order to be able to fulfill on that client service successfully. So beautiful. The closer fills out a client onboarding form. This had the added benefit of making sure that my back end team was never bothering my sales team because the sales team was handing off all of the critical information automatically to the back end team. And they never had to go back to sales and bother them in the middle of their important day taking calls to ask, where are we at with this client? Or what did that client agree to? Or what's their payment plan? All of that was added into the form. OK, beautiful. So the form is what kicked off the entire onboarding automation. From the form, two things happened. Number one, the onboarding SOP was duplicated and assigned. When we were small, this was literally just a VA. Every time a new client onboarding form came in and we got the notification in Slack, they would go into our onboarding SOP inside of our SOP warehouse. They would duplicate that checklist SOP template. They would assign the relevant account manager, the relevant media buyer, the entire fulfillment team to that client that needed to be present for that onboarding process. They would assign out every single task. They would set a due date for every single task, right? So whether this happens manually or if you want to make it fancy, you can do this automatically. The onboarding SOP got duplicated and assigned out. Beautiful. What happened then? All of those tasks got pushed to people's individual to-do lists. So again, I haven't seen a thing. I see a notification coming into Slack with a little hooray sign that we just got in. new client. And what I know is that automatically my entire team has been notified. They all know exactly what tasks they now need to get done by what date. And all of those tasks are sitting in their individual to-do lists, just waiting to get done on the appropriate deadline. Gorgeous. So I can now trust that my client is going to get onboarded seamlessly. I also know that if any individual member of my team gets stuck or blocked or the client onboarding gets off track and slowed down, then those issues are going to be raised and automatically added to our client success huddle. We had a quick huddle every single day. So within 24 hours, I knew that that client block was going to become unblocked and the onboarding would get back on track. And again, all of that is without any input from me. I said that there were two things got fired off of that initial onboarding form. So the first was the SOP and the workflow that ensured my team onboarded this client directly. The second was the information flow. So all of the information that was taken out of that client onboarding form got automatically populated into our master client dashboard. Master dashboard, that master client tracker was now automatically updated. I could see that the new client was in there. I could see all the relevant information for that client, their billing email and their address and the name of their dog, whatever was important information for me and my client success team to see, it was automatically added to the client tracker. As the client moved through the onboarding process and went from onboarding started to onboarding finalized to launch, the status within the client tracker would change so that at a glance, I could go into our master client tracker. I could see exactly how many clients were in the onboarding process and exactly where in the process they were. So the dashboard offered me real time visibility into that process. If I ever cared to jump in there and take a look between you and me, I never did. And I never had to because I trusted that the system was going to manage that entire process for me. And I added even one more step, which is that I would get automatically notified if a process was blocked or overdue. I would get notified via the meeting, my team telling me that there was some issue, and I would get notified when that client was successfully onboarded. I set the notifications in my project management system to notify me automatically and directly when these major milestones were on track or off track. What that meant is that I was now able to track our entire onboarding process. I could measure exactly how efficiently or inefficiently we were getting things done. I could see exactly which tasks were the ones that were consistently blocking us or holding us up. I could make ongoing and continuous improvements to that process so that every single time we onboarded a client, we got slightly better and slightly better and slightly better until the entire process was as fast and efficient and automated and streamlined as possible. So the process of the SOP warehouse pushing tasks into individual to-do lists that got escalated to meeting agendas when necessary, all of that backed by that information being tracked and kept up to date in master dashboards, aka the entire single source of truth system working in harmony, working together. Allowed me to take one of the most complicated processes, one of the most important moments in our client happiness journey, and put it on autopilot with a safety net in place so that I would personally get notified only if and when there was a problem. And I could see the analytics and have the visibility into that process to consistently make improvements to it all the time. Allowed us to take a process that our competitors were generally spending between seven to 10 days on. And our onboarding process got done every time within two to maximum three days. We moved faster as a team. We moved more efficiently as a team. We were spending our time doing the most important work, namely onboarding the client and getting them live to give them a wow experience. And we were spending none of our time trying to track down information, trying to figure out where in the process we were, trying to pick up dropped balls if and when they got dropped, trying to fight the fire when somebody forgot a task and now the client was pissed. None of that happened because the system ensured that the right work got done with or without me. Again, this is just one example of what a truly working single source of truth can do for you and can do for your team. I hope that this illustrates the power of this system. And I wanted to take a moment to talk you through an in-depth example like that, because the reality is that this project will take work. It takes work to build and maintain a single source of truth. It's going to take work for you to turn. this outline around to your team and for them to centralize it and populate it and pull all of that information in. It's going to take work for them to keep those master dashboards up to date. It's going to take work for them to change their habits and their behaviors so that they get used to using this system exactly this way. I'm not going to lie to you. It's hard. So it's important to remember why it's worth the hard. Why it makes not just our life, but our team's life way easier. Why it makes our business way faster, way more productive, way more profitable. And why with all of that saved time and energy, we can now devote all of that back to the highest value driving activities that are going to drive growth into our company. So yes, it is hard. And yes, it is also absolutely worth it. So with all that being said, let's now bring this all together. Let's click back to the worksheet and build the final outline of exactly what is going to go into your single source of truth. We really are at the end here. So let's bring all of this together and produce a final and tangible deliverable, which is your final outline. So we have now listed out across this worksheet, all the very many things, all the very many lists, the different SOPs, all of the stuff that we want our single source of truth to have. The final step is to now reorganize it all into a single comprehensive outline. So it's a three-step process here. Step one, decide on the folder structure that you want to organize everything. This is the macro folder structure. So I would advise having a folder for each department as well as each major product. So if you only have one product, maybe you don't need this. Maybe you just have a product folder and then that's everything regarding your product. But if you have a couple of different tiers of products and these products have different SOPs, different team members running them, then I would recommend taking that one parent product folder and actually just breaking it down into the relevant products that you and your business offer. So you can see my example here in step one. Again, we're not overcomplicating this. It's sales, it's marketing, it's product A, it's product B, right? Keep it very simple, but individualize this to you and your business. What is the macro structure that you want to organize your single source of truth under? Then step number two is we are going to go back to the very beginning of this worksheet. We're going to look at the brain dump of stuff that we put in every single page of this worksheet, and we are going to organize it into the macro folders, right? So where do we want our SOP warehouse? Not to give you the answer, but I'd recommend you put that under operations. Where do we want master dashboards? Those are probably going to be split up within each folder because different departments have different master dashboards that are relevant to them. What about individual to-do lists? Remember, this one you don't have to touch. Individual to-do lists are automatically generated by your single source of truth software, so you shouldn't have to touch that. Meeting agendas, again, do you want meeting agendas under operations or do you want them underneath each individual department and the meetings that that department has? No wrong answers here. I'm giving you my suggestion, but there are no wrong answers here. This is what is going to allow this outline to be as organized and functional for you. You get to decide. You get to customize this. And then lastly, project management. I would again advise that different projects belong to different departments or different products. So each major project management list is going to be separated out and organized accordingly. So take all of the brain dump, all of the different items, all of the different SOPs, everything that we've listed out and now categorize and organize into sub folders or sub lists underneath each of these departments. Gorgeous. So if you scroll down in your worksheet, I have actually given you an example of my personal single source of truth and how it is that we have organized each of these things for ourselves. And you can see that this outline that we're talking about right now is literally what is just going to appear along the left hand side of your click up when you go to build it out or whatever single source of truth software you use. So I've actually labeled where each of these core pillars exist within our system. The individual to-do list function, again, that is built in. That's the home function within ClickUp. For our meeting agendas, we decided to create meeting dashboards. And so each meeting has its own unique dashboard that we custom built out for that meeting. Our SOP warehouse is stored right here, SOP library. It's stored in our operations folder. And if you scroll down, you can see all the very many SOPs organized by core role, core department, core function. You'll see project management. So we had a project called DADA. Too long to get into here, but we had a project called Dada. And this is where we managed the Dada project. We had master dashboards. We had a master client tracker, a retainer client tracker. Those two things were different, right? So we had the master dashboards that were scattered all the way through all of these different folders. If I really expanded every single one of these folders, this example would go on for like four pages. So I tried to keep it short and sweet for you guys. But you'll see down here that we have key folders for each key department and product within our business. One thing that I really like is an executive folder, which you can see this little lock. That means it's private to me where I'm able to track executive level views and visibility across my business. So again, you get to design this now. This is the deliverable. What overarching folders do you want? What master dashboards and projects belong in each of those folders? Where do you want your SOPs stored and listed out? How do you want to structure your meeting agendas? You get to decide. And if you're feeling a little stuck right now, like, oh my God, John, I way too much. I don't know how I want to organize this. The great news is you can always change it later. This is just to give an outline so that you and your team have something to work off of. But any one of these lists can be reorganized into any one of these folders down the road. It's frankly not that irreversible. So my invite is just start. And once you have the outline and you start populating things in and filling things in, you'll figure out what works well for you and for your team. So now there is a step three to this process. And that is once you have this outline completed. Give it to your team and specifically give it to your operator. So if you have that operation specialist on your team, this is their project. It's going to probably take them like the next one to three months to populate all of the things in that you want. But give this to your operator. This is their skill set. This is their job. This is like giving a kid a sandbox to play in. Like they will be so excited that you want them to redesign and build out a company wide system like they can't wait. Right. So give them this project, set realistic timeline expectations with them around how long it's going to take. Again, I recommend two to three months before this is fully built and working within the business and let them work their magic. You have now done your part. You are clear on what this system needs to include, how you want it organized and what it should display. Now let your operator go to work. If you don't have an operator, then do me a kindness and go check out the other live masterclass that I did in SaaS Academy. It's called your A-Player Operator Magnet. And that goes through my entire hiring process for finding and hiring your operator. One of the biggest questions I always get is, well, what if I hire an ops manager? What are they going to be doing? This. They are going to be building out, designing, optimizing, and continuously updating and evolving your single source of truth as your company continues to grow and evolve. This is their baby. And if you recognize that your company is at the size that you really need a system like this, and you absolutely do not have the time to go in and build it out yourself, then that might be a good indicator that it is time for you to hire an ops manager. So again, go over, check the A player operator magnet. If you want my blow by blow on exactly who that person is, what they should be doing, how much to pay them, how to hire them, the works. It is all there for you. Okay, we are here now. Congratulations. And to be clear, the work is just beginning. Now we understand what this system is. It is time to build it within your company. It is time to use it across you and your team. And I promise you that if you commit to that process, because it's not going to be easy, it's going to take time. But if you commit to it, it will fundamentally transform the day-to-day of your business. It will not only radically improve the productivity of your team, it will not only massively speed up your team's execution and ability to get work done, it will not only ensure that you are able to scale at maximum profitability and keep your team as small and lean as possible at each stage of growth, but it will also vastly improve the day-to-day experience that you have of running your business. Because now all of your time and energy will be freed up from the dropped balls and the micro detail and being down stuck in the weeds of your business. And you can hand all of that off to the system itself and get back to doing the things you love the most, doing the things you are best at, and doing the things that drive real value to your company. I cannot wait to see your business transformed by this system. And I cannot wait to support you in the next steps of this journey. My name is Jonna Lee. A massive thank you for letting me guide you through this process. And I will see you very soon.",
+  "segments": [
+    {
+      "text": " I bet you thought we were done, right?",
+      "start": 10.2,
+      "end": 11.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Like five pillars in a single source of truth.",
+      "start": 12.4,
+      "end": 14.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We've got five videos covering those pillars.",
+      "start": 15.2,
+      "end": 17.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We're good, Jonna.",
+      "start": 17.2,
+      "end": 17.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I got it.",
+      "start": 17.9,
+      "end": 18.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I know we are so close, but there is one final topic to cover, which is bringing all five of these pillars in your single source of truth together.",
+      "start": 19.1,
+      "end": 30.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Because the real power of this system is not each individual pillar.",
+      "start": 31.2,
+      "end": 36.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's how these pillars fit and automatically sync together to create one cohesive single source of truth that runs the day to day of your business.",
+      "start": 36.9,
+      "end": 49,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So I want to take some time here just to dive a little bit deeper into how all of these different pillars work and play together and give you a tactical example so that you can understand firsthand",
+      "start": 49.1,
+      "end": 61.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " how having this new system running within your business with all five pillars firing on all cylinders is going to be absolutely transformative.",
+      "start": 61.7,
+      "end": 71.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So if you will bear with me, we have one final topic to cover together.",
+      "start": 71.8,
+      "end": 76.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And then I am going to walk you through building out and finalizing the tangible deliverable of all of this information, which is going to be the finished outline of your single source of truth.",
+      "start": 76.6,
+      "end": 88.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So let's dive into it by starting with a tangible, a tactical example about how each of these core pillars in the single source of truth work together seamlessly in the background to create one",
+      "start": 88.6,
+      "end": 101.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " maximally efficient team for you and for your business.",
+      "start": 101.6,
+      "end": 105,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " The example that I want to use is client onboarding, because traditionally client onboarding is a mess in just about every business I've ever looked at or worked with.",
+      "start": 105.4,
+      "end": 114.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Why?",
+      "start": 115.1,
+      "end": 115.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Because it's so complicated.",
+      "start": 115.7,
+      "end": 117.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It requires so many different steps from so many different people that need to happen in really tight order back to back to back as quickly as possible.",
+      "start": 117.6,
+      "end": 125.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And any mistake pisses off your client and really incurs a very real risk that they might leave.",
+      "start": 125.7,
+      "end": 132.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Right.",
+      "start": 133,
+      "end": 133.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Like mistakes in client onboarding totally destroy client trust and client experience.",
+      "start": 133.2,
+      "end": 139.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And we know how much that costs us in the form of lower client lifetime value.",
+      "start": 139.3,
+      "end": 145.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So client onboarding is a great one because it's super hard to do well and it's super high stakes.",
+      "start": 145.6,
+      "end": 151.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So let's talk about how we could use our single source of truth once it's all built out to make client onboarding not just fast, not just frictionless, but actually fully automated.",
+      "start": 152.3,
+      "end": 165.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I mentioned that when I ran a digital marketing agency, we were onboarding two to four clients a day, and that entire process happened on autopilot, meaning I did not look at it once.",
+      "start": 165.7,
+      "end": 177.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I trusted the system to run this incredibly complicated multi-step process without me.",
+      "start": 177.7,
+      "end": 183.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What did that look like?",
+      "start": 183.9,
+      "end": 184.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It looked something like this.",
+      "start": 185.2,
+      "end": 186.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So we had a new client.",
+      "start": 186.9,
+      "end": 188.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Our closer hopped on a call with them and closed them.",
+      "start": 188.5,
+      "end": 190.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Fantastic.",
+      "start": 190.4,
+      "end": 191.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " As soon as that client hopped off the call, the very next step would be for my closer to fill out what we called a client onboarding form.",
+      "start": 191.5,
+      "end": 199.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " You've got one form with all of the critical information about that client and everything that the back end team needs in order to be able to fulfill on that client service successfully.",
+      "start": 200.4,
+      "end": 211.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So beautiful.",
+      "start": 211.7,
+      "end": 212.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " The closer fills out a client onboarding form.",
+      "start": 212.5,
+      "end": 214.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This had the added benefit of making sure that my back end team was never bothering my sales team because the sales team was handing off all of the critical information automatically to the back end team.",
+      "start": 214.9,
+      "end": 227,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And they never had to go back to sales and bother them in the middle of their important day taking calls to ask, where are we at with this client?",
+      "start": 227.2,
+      "end": 234.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Or what did that client agree to?",
+      "start": 234.4,
+      "end": 235.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Or what's their payment plan?",
+      "start": 235.5,
+      "end": 236.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " All of that was added into the form.",
+      "start": 236.9,
+      "end": 238.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " OK, beautiful.",
+      "start": 239,
+      "end": 239.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So the form is what kicked off the entire onboarding automation.",
+      "start": 239.9,
+      "end": 244.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " From the form, two things happened.",
+      "start": 244.7,
+      "end": 246.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Number one, the onboarding SOP was duplicated and assigned.",
+      "start": 246.8,
+      "end": 251,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " When we were small, this was literally just a VA.",
+      "start": 251.3,
+      "end": 254,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Every time a new client onboarding form came in and we got the notification in Slack, they would go into our onboarding SOP inside of our SOP warehouse.",
+      "start": 254.4,
+      "end": 262.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " They would duplicate that checklist SOP template.",
+      "start": 263.1,
+      "end": 267,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " They would assign the relevant account manager, the relevant media buyer, the entire fulfillment team to that client that needed to be present for that onboarding process.",
+      "start": 267.4,
+      "end": 275.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " They would assign out every single task.",
+      "start": 275.6,
+      "end": 277.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " They would set a due date for every single task, right?",
+      "start": 277.4,
+      "end": 280.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So whether this happens manually or if you want to make it fancy, you can do this automatically.",
+      "start": 280.5,
+      "end": 284.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " The onboarding SOP got duplicated and assigned out.",
+      "start": 284.8,
+      "end": 287.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Beautiful.",
+      "start": 287.9,
+      "end": 288.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What happened then?",
+      "start": 288.2,
+      "end": 288.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " All of those tasks got pushed to people's individual to-do lists.",
+      "start": 289.3,
+      "end": 293.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So again, I haven't seen a thing.",
+      "start": 293.8,
+      "end": 295.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I see a notification coming into Slack with a little hooray sign that we just got in.",
+      "start": 295.8,
+      "end": 300,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " new client.",
+      "start": 300,
+      "end": 300.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And what I know is that automatically my entire team has been notified.",
+      "start": 300.8,
+      "end": 304.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " They all know exactly what tasks they now need to get done by what date.",
+      "start": 304.8,
+      "end": 308.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And all of those tasks are sitting in their individual to-do lists, just waiting to get done on the appropriate deadline.",
+      "start": 308.7,
+      "end": 314.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Gorgeous.",
+      "start": 315.3,
+      "end": 315.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So I can now trust that my client is going to get onboarded seamlessly.",
+      "start": 316,
+      "end": 321,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I also know that if any individual member of my team gets stuck or blocked or the client onboarding gets off track and slowed down, then those issues are going to be raised and automatically added to our client success huddle.",
+      "start": 321.9,
+      "end": 336.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We had a quick huddle every single day.",
+      "start": 336.6,
+      "end": 338.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So within 24 hours, I knew that that client block was going to become unblocked and the onboarding would get back on track.",
+      "start": 338.7,
+      "end": 345.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And again, all of that is without any input from me.",
+      "start": 345.3,
+      "end": 349,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I said that there were two things got fired off of that initial onboarding form.",
+      "start": 349.1,
+      "end": 353.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So the first was the SOP and the workflow that ensured my team onboarded this client directly.",
+      "start": 353.1,
+      "end": 358.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " The second was the information flow.",
+      "start": 358.6,
+      "end": 361.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So all of the information that was taken out of that client onboarding form got automatically populated into our master client dashboard.",
+      "start": 361.4,
+      "end": 370.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Master dashboard, that master client tracker was now automatically updated.",
+      "start": 370.4,
+      "end": 374.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I could see that the new client was in there.",
+      "start": 374.9,
+      "end": 376.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I could see all the relevant information for that client, their billing email and their address and the name of their dog, whatever was important information for me and my client success team to see, it was automatically added to the client tracker.",
+      "start": 376.8,
+      "end": 389.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " As the client moved through the onboarding process and went from onboarding started to onboarding finalized to launch, the status within the client tracker would change so that at a glance, I could go into our master client tracker.",
+      "start": 389.9,
+      "end": 403.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I could see exactly how many clients were in the onboarding process and exactly where in the process they were.",
+      "start": 403.6,
+      "end": 409.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So the dashboard offered me real time visibility into that process.",
+      "start": 410,
+      "end": 414.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " If I ever cared to jump in there and take a look between you and me, I never did.",
+      "start": 414.3,
+      "end": 418.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And I never had to because I trusted that the system was going to manage that entire process for me.",
+      "start": 418.9,
+      "end": 424.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And I added even one more step, which is that I would get automatically notified if a process was blocked or overdue.",
+      "start": 424.6,
+      "end": 431.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I would get notified via the meeting, my team telling me that there was some issue, and I would get notified when that client was successfully onboarded.",
+      "start": 431.6,
+      "end": 439.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I set the notifications in my project management system to notify me automatically and directly when these major milestones were on track or off track.",
+      "start": 439.2,
+      "end": 447.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What that meant is that I was now able to track our entire onboarding process.",
+      "start": 447.7,
+      "end": 452.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I could measure exactly how efficiently or inefficiently we were getting things done.",
+      "start": 452.6,
+      "end": 457.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I could see exactly which tasks were the ones that were consistently blocking us or holding us up.",
+      "start": 458,
+      "end": 464.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I could make ongoing and continuous improvements to that process so that every single time we onboarded a client, we got slightly better and slightly better and slightly better until the entire process was as fast and efficient and automated and streamlined as",
+      "start": 464.8,
+      "end": 479.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " possible.",
+      "start": 479.8,
+      "end": 480.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So the process of the SOP warehouse pushing tasks into individual to-do lists that got escalated to meeting agendas when necessary, all of that backed by that information being tracked and kept up to date in master dashboards,",
+      "start": 480.5,
+      "end": 494.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " aka the entire single source of truth system working in harmony, working together.",
+      "start": 495.3,
+      "end": 501.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Allowed me to take one of the most complicated processes, one of the most important moments in our client happiness journey, and put it on autopilot with a safety net in place so that I would personally get notified",
+      "start": 502.5,
+      "end": 516.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " only if and when there was a problem.",
+      "start": 516.6,
+      "end": 519.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And I could see the analytics and have the visibility into that process to consistently make improvements to it all the time.",
+      "start": 519.5,
+      "end": 527.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Allowed us to take a process that our competitors were generally spending between seven to 10 days on.",
+      "start": 528.1,
+      "end": 533.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And our onboarding process got done every time within two to maximum three days.",
+      "start": 533.8,
+      "end": 539.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We moved faster as a team.",
+      "start": 539.8,
+      "end": 541.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We moved more efficiently as a team.",
+      "start": 541.8,
+      "end": 544.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We were spending our time doing the most important work, namely onboarding the client and getting them live to give them a wow experience.",
+      "start": 544.2,
+      "end": 551.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And we were spending none of our time trying to track down information, trying to figure out where in the process we were, trying to pick up dropped balls if and when they got dropped, trying to fight the fire when somebody forgot a task and now the client was pissed.",
+      "start": 551.7,
+      "end": 564.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " None of that happened because the system ensured that the right work got done with or without me.",
+      "start": 565.1,
+      "end": 572.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Again, this is just one example of what a truly working single source of truth can do for you and can do for your team.",
+      "start": 573.1,
+      "end": 580,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I hope that this illustrates the power of this system.",
+      "start": 580.2,
+      "end": 583.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And I wanted to take a moment to talk you through an in-depth example like that, because the reality is that this project will take work.",
+      "start": 583.6,
+      "end": 592.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It takes work to build and maintain a single source of truth.",
+      "start": 593.4,
+      "end": 598.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's going to take work for you to turn.",
+      "start": 598.2,
+      "end": 600,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " this outline around to your team and for them to centralize it and populate it and pull all of that information in.",
+      "start": 600.1,
+      "end": 606.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's going to take work for them to keep those master dashboards up to date.",
+      "start": 606.5,
+      "end": 610.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's going to take work for them to change their habits and their behaviors so that they get used to using this system exactly this way.",
+      "start": 610.5,
+      "end": 618.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I'm not going to lie to you.",
+      "start": 618.6,
+      "end": 619.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's hard.",
+      "start": 620,
+      "end": 620.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So it's important to remember why it's worth the hard.",
+      "start": 621,
+      "end": 626,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Why it makes not just our life, but our team's life way easier.",
+      "start": 626.7,
+      "end": 630.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Why it makes our business way faster, way more productive, way more profitable.",
+      "start": 631.3,
+      "end": 636.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And why with all of that saved time and energy, we can now devote all of that back to the highest value driving activities that are going to drive growth into our company.",
+      "start": 637,
+      "end": 649.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So yes, it is hard.",
+      "start": 650,
+      "end": 651.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And yes, it is also absolutely worth it.",
+      "start": 651.8,
+      "end": 655.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So with all that being said, let's now bring this all together.",
+      "start": 656.4,
+      "end": 660.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Let's click back to the worksheet and build the final outline of exactly what is going to go into your single source of truth.",
+      "start": 660.2,
+      "end": 667.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We really are at the end here.",
+      "start": 668.3,
+      "end": 670,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So let's bring all of this together and produce a final and tangible deliverable, which is your final outline.",
+      "start": 670.1,
+      "end": 677,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So we have now listed out across this worksheet, all the very many things, all the very many lists, the different SOPs, all of the stuff that we want our single source of truth to have.",
+      "start": 677.4,
+      "end": 688.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " The final step is to now reorganize it all into a single comprehensive outline.",
+      "start": 688.8,
+      "end": 693.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So it's a three-step process here.",
+      "start": 694,
+      "end": 695.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Step one, decide on the folder structure that you want to organize everything.",
+      "start": 695.8,
+      "end": 700.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is the macro folder structure.",
+      "start": 700.7,
+      "end": 703,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So I would advise having a folder for each department as well as each major product.",
+      "start": 703.1,
+      "end": 708.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So if you only have one product, maybe you don't need this.",
+      "start": 709.2,
+      "end": 712.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Maybe you just have a product folder and then that's everything regarding your product.",
+      "start": 712.2,
+      "end": 715.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " But if you have a couple of different tiers of products and these products have different SOPs, different team members running them, then I would recommend",
+      "start": 715.4,
+      "end": 723.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " taking that one parent product folder and actually just breaking it down into the relevant products that you and your business offer.",
+      "start": 724.1,
+      "end": 730.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So you can see my example here in step one.",
+      "start": 730.9,
+      "end": 733.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Again, we're not overcomplicating this.",
+      "start": 733.6,
+      "end": 735.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's sales, it's marketing, it's product A, it's product B, right?",
+      "start": 735.1,
+      "end": 737.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Keep it very simple, but individualize this to you and your business.",
+      "start": 737.9,
+      "end": 742.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What is the macro structure that you want to organize your single source of truth under?",
+      "start": 742.1,
+      "end": 746.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Then step number two is we are going to go back to the very beginning of this worksheet.",
+      "start": 747.5,
+      "end": 752.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We're going to look at the brain dump of stuff that we put in every single page of this worksheet, and we are going to organize it into the macro folders, right?",
+      "start": 752.6,
+      "end": 763.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So where do we want our SOP warehouse?",
+      "start": 763.5,
+      "end": 765.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Not to give you the answer, but I'd recommend you put that under operations.",
+      "start": 766,
+      "end": 769,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Where do we want master dashboards?",
+      "start": 769.3,
+      "end": 771,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Those are probably going to be split up within each folder because different departments have different master dashboards that are relevant to them.",
+      "start": 771.1,
+      "end": 778.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What about individual to-do lists?",
+      "start": 778.8,
+      "end": 780.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Remember, this one you don't have to touch.",
+      "start": 780.4,
+      "end": 782.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Individual to-do lists are automatically generated by your single source of truth software, so you shouldn't have to touch that.",
+      "start": 782.7,
+      "end": 788.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Meeting agendas, again, do you want meeting agendas under operations or do you want them underneath each individual department and the meetings that that department has?",
+      "start": 789.3,
+      "end": 796.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " No wrong answers here.",
+      "start": 797.4,
+      "end": 798.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I'm giving you my suggestion, but there are no wrong answers here.",
+      "start": 798.8,
+      "end": 802.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is what is going to allow this outline to be as organized and functional for you.",
+      "start": 802.7,
+      "end": 807.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " You get to decide.",
+      "start": 807.9,
+      "end": 808.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " You get to customize this.",
+      "start": 809,
+      "end": 810.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And then lastly, project management.",
+      "start": 810.8,
+      "end": 812.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I would again advise that different projects belong to different departments or different products.",
+      "start": 812.4,
+      "end": 817.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So each major project management list is going to be separated out and organized accordingly.",
+      "start": 817.3,
+      "end": 823.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So take all of the brain dump, all of the different items, all of the different SOPs, everything that we've listed out and now categorize and organize into sub folders or sub lists underneath each of these departments.",
+      "start": 823.9,
+      "end": 837.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Gorgeous.",
+      "start": 837.6,
+      "end": 838.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So if you scroll down in your worksheet, I have actually given you an example of my personal single source of truth and how it is that we have organized each of these things for ourselves.",
+      "start": 838.8,
+      "end": 849.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And you can see that this outline that we're talking about right now is literally what is just going to appear along the left hand side of your click up when you go to build it out or whatever single source of truth software you use.",
+      "start": 850.5,
+      "end": 862.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So I've actually labeled where each of these core pillars exist within our system.",
+      "start": 863.2,
+      "end": 867.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " The individual to-do list function, again, that is built in.",
+      "start": 868.1,
+      "end": 871.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " That's the home function within ClickUp.",
+      "start": 871.2,
+      "end": 873.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " For our meeting agendas, we decided to create meeting dashboards.",
+      "start": 873.7,
+      "end": 877,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And so each meeting has its own unique dashboard that we custom built out for that meeting.",
+      "start": 877.2,
+      "end": 882.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Our SOP warehouse is stored right here, SOP library.",
+      "start": 882.9,
+      "end": 886,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's stored in our operations folder.",
+      "start": 886.3,
+      "end": 888,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And if you scroll down, you can see all the very many SOPs organized by core role, core department, core function.",
+      "start": 888.2,
+      "end": 895.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " You'll see project management.",
+      "start": 896.3,
+      "end": 897.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So we had a project called DADA.",
+      "start": 897.6,
+      "end": 899.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Too long to get into here, but we had a project called Dada.",
+      "start": 900,
+      "end": 902.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And this is where we managed the Dada project.",
+      "start": 902.8,
+      "end": 905.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We had master dashboards.",
+      "start": 905.7,
+      "end": 907,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " We had a master client tracker, a retainer client tracker.",
+      "start": 907,
+      "end": 909.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Those two things were different, right?",
+      "start": 909.4,
+      "end": 910.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So we had the master dashboards that were scattered all the way through all of these different folders.",
+      "start": 911,
+      "end": 916.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " If I really expanded every single one of these folders, this example would go on for like four pages.",
+      "start": 916.6,
+      "end": 921.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So I tried to keep it short and sweet for you guys.",
+      "start": 921.8,
+      "end": 924,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " But you'll see down here that we have key folders for each key department and product within our business.",
+      "start": 924.3,
+      "end": 931,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " One thing that I really like is an executive folder, which you can see this little lock.",
+      "start": 931.5,
+      "end": 935.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " That means it's private to me where I'm able to track executive level views and visibility across my business.",
+      "start": 935.5,
+      "end": 941.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So again, you get to design this now.",
+      "start": 941.3,
+      "end": 944,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is the deliverable.",
+      "start": 944,
+      "end": 945.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What overarching folders do you want?",
+      "start": 945.6,
+      "end": 948.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What master dashboards and projects belong in each of those folders?",
+      "start": 948.4,
+      "end": 952.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Where do you want your SOPs stored and listed out?",
+      "start": 952.3,
+      "end": 955.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " How do you want to structure your meeting agendas?",
+      "start": 955.7,
+      "end": 957.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " You get to decide.",
+      "start": 958.1,
+      "end": 959.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And if you're feeling a little stuck right now, like, oh my God, John, I way too much.",
+      "start": 959.5,
+      "end": 962.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I don't know how I want to organize this.",
+      "start": 962.6,
+      "end": 964.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " The great news is you can always change it later.",
+      "start": 964.6,
+      "end": 968.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is just to give an outline so that you and your team have something to work off of.",
+      "start": 968.6,
+      "end": 973.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " But any one of these lists can be reorganized into any one of these folders down the road.",
+      "start": 974.1,
+      "end": 979.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's frankly not that irreversible.",
+      "start": 979.2,
+      "end": 981.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So my invite is just start.",
+      "start": 981.7,
+      "end": 984.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And once you have the outline and you start populating things in and filling things in, you'll figure out what works well for you and for your team.",
+      "start": 984.6,
+      "end": 992.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So now there is a step three to this process.",
+      "start": 993.2,
+      "end": 995.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And that is once you have this outline completed.",
+      "start": 996.1,
+      "end": 998.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Give it to your team and specifically give it to your operator.",
+      "start": 999.4,
+      "end": 1004.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So if you have that operation specialist on your team, this is their project.",
+      "start": 1005,
+      "end": 1011.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's going to probably take them like the next one to three months to populate all of the things in that you want.",
+      "start": 1011.9,
+      "end": 1017.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " But give this to your operator.",
+      "start": 1018.1,
+      "end": 1019.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is their skill set.",
+      "start": 1019.9,
+      "end": 1021.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is their job.",
+      "start": 1021.8,
+      "end": 1023.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is like giving a kid a sandbox to play in.",
+      "start": 1023.2,
+      "end": 1026.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Like they will be so excited that you want them to redesign and build out a company wide system like they can't wait.",
+      "start": 1026.3,
+      "end": 1032.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Right.",
+      "start": 1032.9,
+      "end": 1033.1,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So give them this project, set realistic timeline expectations with them around how long it's going to take.",
+      "start": 1033.3,
+      "end": 1038.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Again, I recommend two to three months before this is fully built and working within the business and let them work their magic.",
+      "start": 1038.9,
+      "end": 1047.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " You have now done your part.",
+      "start": 1047.5,
+      "end": 1048.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " You are clear on what this system needs to include, how you want it organized and what it should display.",
+      "start": 1048.9,
+      "end": 1055.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Now let your operator go to work.",
+      "start": 1055.7,
+      "end": 1058.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " If you don't have an operator, then do me a kindness and go check out the other live masterclass that I did in SaaS Academy.",
+      "start": 1059.1,
+      "end": 1066,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It's called your A-Player Operator Magnet.",
+      "start": 1066.2,
+      "end": 1069,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And that goes through my entire hiring process for finding and hiring your operator.",
+      "start": 1069.2,
+      "end": 1074,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " One of the biggest questions I always get is, well, what if I hire an ops manager?",
+      "start": 1074.3,
+      "end": 1077.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " What are they going to be doing?",
+      "start": 1078,
+      "end": 1079,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This.",
+      "start": 1080.2,
+      "end": 1080.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " They are going to be building out, designing, optimizing, and continuously updating and evolving your single source of truth as your company continues to grow and evolve.",
+      "start": 1081.1,
+      "end": 1092.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " This is their baby.",
+      "start": 1092.3,
+      "end": 1094.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And if you recognize that your company is at the size that you really need a system like this, and you absolutely do not have the time to go in and build it out yourself, then that might be a good indicator that it is time for you to hire an ops manager.",
+      "start": 1094.6,
+      "end": 1108.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " So again, go over, check the A player operator magnet.",
+      "start": 1108.8,
+      "end": 1111.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " If you want my blow by blow on exactly who that person is, what they should be doing, how much to pay them, how to hire them, the works.",
+      "start": 1111.7,
+      "end": 1117.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It is all there for you.",
+      "start": 1117.9,
+      "end": 1119.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Okay, we are here now.",
+      "start": 1120.4,
+      "end": 1123,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Congratulations.",
+      "start": 1123.2,
+      "end": 1124.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And to be clear, the work is just beginning.",
+      "start": 1124.8,
+      "end": 1127.7,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Now we understand what this system is.",
+      "start": 1128.2,
+      "end": 1130,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It is time to build it within your company.",
+      "start": 1130.2,
+      "end": 1132.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It is time to use it across you and your team.",
+      "start": 1132.8,
+      "end": 1136,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And I promise you that if you commit to that process, because it's not going to be easy, it's going to take time.",
+      "start": 1136.4,
+      "end": 1142.3,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " But if you commit to it, it will fundamentally transform the day-to-day of your business.",
+      "start": 1142.6,
+      "end": 1149.9,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " It will not only radically improve the productivity of your team, it will not only",
+      "start": 1150.2,
+      "end": 1156,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " massively speed up your team's execution and ability to get work done, it will not only ensure that you are able to scale at maximum profitability",
+      "start": 1156.3,
+      "end": 1167.2,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " and keep your team as small and lean as possible at each stage of growth, but it will also vastly improve the day-to-day experience that you have of running your business.",
+      "start": 1167.6,
+      "end": 1179,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " Because now all of your time and energy will be freed up from the dropped balls and the micro detail and being down stuck in the weeds of your business.",
+      "start": 1179.4,
+      "end": 1187.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And you can hand all of that off to the system itself and get back to doing the things you love the most, doing the things you are best at, and doing the things that drive real",
+      "start": 1188.3,
+      "end": 1199.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " value to your company.",
+      "start": 1200.1,
+      "end": 1202.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " I cannot wait to see your business transformed by this system.",
+      "start": 1202.7,
+      "end": 1208.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And I cannot wait to support you in the next steps of this journey.",
+      "start": 1208.6,
+      "end": 1213.8,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " My name is Jonna Lee.",
+      "start": 1214.3,
+      "end": 1215.6,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " A massive thank you for letting me guide you through this process.",
+      "start": 1215.9,
+      "end": 1219.4,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    },
+    {
+      "text": " And I will see you very soon.",
+      "start": 1219.7,
+      "end": 1221.5,
+      "type": "transcription_segment",
+      "speaker_id": "speaker_1"
+    }
+  ],
+  "usage": {
+    "promptTokens": 25,
+    "completionTokens": 6300,
+    "totalTokens": 6325,
+    "promptAudioSeconds": 1225,
+    "additionalProperties": {
+      "request_count": 5,
+      "num_cached_tokens": 0
+    }
+  },
+  "language": null,
+  "additionalProperties": {
+    "type": "transcription.done"
+  }
+}

--- a/test/support/data/mistral_voxtral-word-level.json
+++ b/test/support/data/mistral_voxtral-word-level.json
@@ -1,0 +1,21512 @@
+{
+  "model": "voxtral-mini-latest",
+  "text": "I bet you thought we were done, right? Like five pillars in the single source of truth. We've got five videos covering those pillars. We're good, Jonna. I got it. I know we are so close, but there is one final topic to cover, which is bringing all five of these pillars in your single source of truth together. Because the real power of this system is not each individual pillar. It's how these pillars fit and automatically sync together to create one cohesive single source of truth that runs the day to day of your business. So I want to take some time here just to dive a little bit deeper into how all of these different pillars work and play together and give you a tactical example so that you can understand firsthand how having this new system running within your business with all five pillars firing on all cylinders is going to be absolutely transformative. So if you will bear with me, we have one final topic to cover together. And then I am going to walk you through building out and finalizing the tangible deliverable of all of this information, which is going to be the finished outline of your single source of truth. So let's dive into it by starting with a tangible, a tactical example about how each of these core pillars in the single source of truth work together seamlessly in the background to create one maximally efficient team for you and for your business. The example that I want to use is client onboarding, because traditionally client onboarding is a mess in just about every business I've ever looked at or worked with. Why? Because it's so complicated. It requires so many different steps from so many different people that need to happen in really tight order back to back to back as quickly as possible. And any mistake pisses off your client and really incurs a very real risk that they might leave, right? Like mistakes in client onboarding totally destroy client trust and client experience. And we know how much that costs us in the form of lower client lifetime value. So client onboarding is a great one because it's super hard to do well and it's super high stakes. So let's talk about how we could use our single source of truth once it's all built out to make client onboarding not just fast, not just frictionless, but actually fully automated. I mentioned that when I ran a digital marketing agency, we were onboarding two to four clients a day, and that entire process happened on autopilot, meaning I did not look at it once. I trusted the system to run this incredibly complicated multi-step process without me. What did that look like? It looked something like this. So we had a new client. Our closer hopped on a call with them and closed them. Fantastic. As soon as that client hopped off the call, the very next step would be for my closer to fill out what we called a client onboarding form. You've got one form with all of the critical information about that client and everything that the back end team needs in order to be able to fulfill on that client service successfully. So beautiful. The closer fills out a client onboarding form. This had the added benefit of making sure that my back end team was never bothering my sales team because the sales team was handing off all of the critical information automatically to the back end team. And they never had to go back to sales and bother them in the middle of their important day taking calls to ask where are we at with this client or what did that client agree to or what's their payment plan? All of that was added into the form. OK, beautiful. So the form is what kicked off the entire onboarding automation. From the form, two things happened. Number one, the onboarding SOP was duplicated and assigned. When we were small, this was literally just a VA that every time a new client onboarding form came in and we got the notification in Slack, they would go into our onboarding SOP inside of our SOP warehouse. They would duplicate that checklist SOP template. They would assign the relevant account manager, the relevant media buyer, the entire fulfillment team to that client that needed to be present for that onboarding process. They would assign out every single task. They would set a due date for every single task, right? So whether this happens manually or if you want to make it fancy, you can do this automatically. The onboarding SOP got duplicated and assigned out. Beautiful. What happened then? All of those tasks got pushed to people's individual to-do lists. So again, I haven't seen a thing. I see a notification coming into Slack with a little hooray sign that we just got in. new client. And what I know is that automatically my entire team has been notified. They all know exactly what tasks they now need to get done by what date. And all of those tasks are sitting in their individual to-do lists, just waiting to get done on the appropriate deadline. Gorgeous. So I can now trust that my client is going to get onboarded seamlessly. I also know that if any individual member of my team gets stuck or blocked or the client onboarding gets off track and slowed down, then those issues are going to be raised and automatically added to our client success huddle. We had a quick huddle every single day. So within 24 hours, I knew that that client block was going to become unblocked and the onboarding would get back on track. And again, all of that is without any input from me. I said that there were two things got fired off of that initial onboarding form. So the first was the SOP and the workflow that ensured my team onboarded this client directly. The second was the information flow. So all of the information that was taken out of that client onboarding form got automatically populated into our master client dashboard. Master dashboard, that master client tracker was now automatically updated. I could see that the new client was in there. I could see all the relevant information for that client, their billing email and their address and the name of their dog, whatever was important information for me and my client success team to see, it was automatically added to the client tracker. As the client moved through the onboarding process and went from onboarding started to onboarding finalized to launch, the status within the client tracker would change so that at a glance, I could go into our master client tracker. I could see exactly how many clients were in the onboarding process and exactly where in the process they were. So the dashboard offered me real time visibility into that process if I ever cared to jump in there and take a look. Between you and me, I never did and I never had to because I trusted that the system was going to manage that entire process for me. And I added even one more step, which is that I would get automatically notified if a process was blocked or overdue. I would get notified via the meeting, my team telling me that there was some issue, and I would get notified when that client was successfully onboarded. I set the notifications in my project management system to notify me automatically and directly when these major milestones were on track or off track. What that meant is that I was now able to track our entire onboarding process. I could measure exactly how efficiently or inefficiently we were getting things done. I could see exactly which tasks were the ones that were consistently blocking us or holding us up. I could make ongoing and continuous improvements to that process so that every single time we onboarded a client, we got slightly better and slightly better and slightly better until the entire process was as fast and efficient and automated and streamlined as possible. So the process of the SOP warehouse pushing tasks into individual to-do lists that got escalated to meeting agendas when necessary, all of that backed by that information being tracked and kept up to date in master dashboards, aka the entire single source of truth system working in harmony, working together. Allowed me to take one of the most complicated processes, one of the most important moments in our client happiness journey, and put it on autopilot with a safety net in place so that I would personally get notified only if and when there was a problem. And I could see the analytics and have the visibility into that process to consistently make improvements to it all the time. Allowed us to take a process that our competitors were generally spending between seven to 10 days on. And our onboarding process got done every time within two to maximum three days. We moved faster as a team. We moved more efficiently as a team. We were spending our time doing the most important work, namely onboarding the client and getting them live to give them a wow experience. And we were spending none of our time trying to track down information, trying to figure out where in the process we were, trying to pick up dropped balls if and when they got dropped, trying to fight the fire when somebody forgot a task and now the client was pissed. None of that happened because the system ensured that the right work got done with or without me. Again, this is just one example of what a truly working single source of truth can do for you and can do for your team. I hope that this illustrates the power of this system. And I wanted to take a moment to talk you through an in-depth example like that, because the reality is that this project will take work. It takes work to build and maintain a single source of truth. It's going to take work for you to turn. this outline around to your team and for them to centralize it and populate it and pull all of that information in. It's going to take work for them to keep those master dashboards up to date. It's going to take work for them to change their habits and their behaviors so that they get used to using this system exactly this way. I'm not going to lie to you. It's hard. So it's important to remember why it's worth the hard. Why it makes not just our life, but our team's life way easier. Why it makes our business way faster, way more productive, way more profitable. And why with all of that saved time and energy, we can now devote all of that back to the highest value driving activities that are going to drive growth into our company. So yes, it is hard. And yes, it is also absolutely worth it. So with all that being said, let's now bring this all together. Let's click back to the worksheet and build the final outline of exactly what is going to go into your single source of truth. We really are at the end here. So let's bring all of this together and produce a final and tangible deliverable, which is your final outline. So we have now listed out across this worksheet all the very many things, all the very many lists, the different SOPs, all of the stuff that we want our single source of truth to have. The final step is to now reorganize it all into a single comprehensive outline. So it's a three step process here. Step one, decide on the folder structure that you want to organize everything. This is the macro folder structure. So I would advise having a folder for each department as well as each major product. So if you only have one product, maybe you don't need this. Maybe you just have a product folder and then that's everything regarding your product. But if you have a couple of different tiers of products and these products have different SOPs, different team members running them, then I would recommend taking that one parent product folder and actually just breaking it down into the relevant products that you and your business offer. So you can see my example here in step one. Again, we're not overcomplicating this. It's sales. It's marketing. It's product A. It's product B, right? Keep it very simple, but individualize this to you and your business. What is the macro structure that you want to organize your single source of truth under? Then step number two is we are going to go back to the very beginning of this worksheet. We're going to look at the brain dump of stuff that we put in every single page of this worksheet, and we are going to organize it into the macro folders, right? So where do we want our SOP warehouse? Not to give you the answer, but I'd recommend you put that under operations. Where do we want master dashboards? Those are probably going to be split up within each folder because different departments have different master dashboards that are relevant to them. What about individual to-do lists? Remember, this one you don't have to touch. Individual to-do lists are automatically generated by your single source of truth software, so you shouldn't have to touch that. Meeting agendas, again, do you want meeting agendas under operations or do you want them underneath each individual department and the meetings that that department has? No wrong answers here. I'm giving you my suggestion, but there are no wrong answers here. This is what is going to allow this outline to be as organized and functional for you. You get to decide. You get to customize this. And then lastly, project management. I would again advise that different projects belong to different departments or different products. So each major project management list is going to be separated out and organized accordingly. So take all of the brain dump, all of the different items, all of the different SOPs, everything that we've listed out and now categorize and organize into sub folders or sub lists underneath each of these departments. Gorgeous. So if you scroll down in your worksheet, I have actually given you an example of my personal single source of truth and how it is that we have organized each of these things for ourselves. And you can see that this outline that we're talking about right now is literally what is just going to appear along the left hand side of your click up when you go to build it out or whatever single source of truth software you use. So I've actually labeled where each of these core pillars exist within our system. The individual to-do list function, again, that is built in. That's the home function within ClickUp. For our meeting agendas, we decided to create meeting dashboards. And so each meeting has its own unique dashboard that we custom built out for that meeting. Our SOP warehouse is stored right here, SOP library. It's stored in our operations folder. And if you scroll down, you can see all the very many SOPs organized by core role, core department, core function. You'll see project management. So we had a project called DADA. Too long to get into here, but we had a project called Data. And this is where we managed the Data project. We had master dashboards. We had a master client tracker, a retainer client tracker. Those two things were different, right? So we had the master dashboards that were scattered all the way through all of these different folders. If I really expanded every single one of these folders, this example would go on for like four pages. So I tried to keep it short and sweet for you guys. But you'll see down here that we have key folders for each key department and product within our business. One thing that I really like is an executive folder, which you can see this little lock. That means it's private to me where I'm able to track executive level views and visibility across my business. So again, you get to design this now. This is the deliverable. What overarching folders do you want? What master dashboards and projects belong in each of those folders? Where do you want your SOPs stored and listed out? How do you want to structure your meeting agendas? You get to decide. And if you're feeling a little stuck right now, like, oh my God, John, I way too much. I don't know how I want to organize this. The great news is you can always change it later. This is just to give an outline so that you and your team have something to work off of. But any one of these lists can be reorganized into any one of these folders down the road. It's frankly not that irreversible. So my invite is just start. And once you have the outline and you start populating things in and filling things in, you'll figure out what works well for you and for your team. So now there is a step three to this process. And that is once you have this outline completed. Give it to your team and specifically give it to your operator. So if you have that operation specialist on your team, this is their project. It's going to probably take them like the next one to three months to populate all of the things in that you want. But give this to your operator. This is their skill set. This is their job. This is like giving a kid a sandbox to play in. Like they will be so excited that you want them to redesign and build out a company wide system like they can't wait. Right. So give them this project, set realistic timeline expectations with them around how long it's going to take. Again, I recommend two to three months before this is fully built and working within the business and let them work their magic. You have now done your part. You are clear on what this system needs to include, how you want it organized and what it should display. Now let your operator go to work. If you don't have an operator, then do me a kindness and go check out the other live masterclass that I did in SaaS Academy. It's called your A-Player Operator Magnet. And that goes through my entire hiring process for finding and hiring your operator. One of the biggest questions I always get is, well, what if I hire an ops manager? What are they going to be doing? This. They are going to be building out, designing, optimizing, and continuously updating and evolving your single source of truth as your company continues to grow and evolve. This is their baby. And if you recognize that your company is at the size that you really need a system like this, and you absolutely do not have the time to go in and build it out yourself, then that might be a good indicator that it is time for you to hire an ops manager. So again, go over, check the A-player operator magnet if you want my blow-by-blow on exactly who that person is, what they should be doing, how much to pay them, how to hire them, the works. It is all there for you. Okay, we are here now. Congratulations. And to be clear, the work is just beginning. Now we understand what this system is. It is time to build it within your company. It is time to use it across you and your team. And I promise you that if you commit to that process, because it's not going to be easy, it's going to take time. But if you commit to it, it will fundamentally transform the day-to-day of your business. It will not only radically improve the productivity of your team, it will not only massively speed up your team's execution and ability to get work done, it will not only ensure that you are able to scale at maximum profitability and keep your team as small and lean as possible at each stage of growth, but it will also vastly improve the day-to-day experience that you have of running your business. Because now all of your time and energy will be freed up from the dropped balls and the micro detail and being down stuck in the weeds of your business. And you can hand all of that off to the system itself and get back to doing the things you love the most, doing the things you are best at, and doing the things that drive real value to your company. I cannot wait to see your business transformed by this system. And I cannot wait to support you in the next steps of this journey. My name is Jonna Lee. A massive thank you for letting me guide you through this process. And I will see you very soon.",
+  "segments": [
+    {
+      "text": " I",
+      "start": 10.2,
+      "end": 10.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bet",
+      "start": 10.3,
+      "end": 10.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 10.5,
+      "end": 10.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " thought",
+      "start": 10.7,
+      "end": 10.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 10.8,
+      "end": 10.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 11,
+      "end": 11.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done,",
+      "start": 11.1,
+      "end": 11.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right?",
+      "start": 11.6,
+      "end": 11.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Like",
+      "start": 12.4,
+      "end": 12.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " five",
+      "start": 13.2,
+      "end": 13.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars",
+      "start": 13.4,
+      "end": 13.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 13.8,
+      "end": 13.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 13.9,
+      "end": 13.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 14,
+      "end": 14.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 14.2,
+      "end": 14.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 14.4,
+      "end": 14.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth.",
+      "start": 14.5,
+      "end": 14.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We've",
+      "start": 15.2,
+      "end": 15.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 15.3,
+      "end": 15.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " five",
+      "start": 15.5,
+      "end": 15.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " videos",
+      "start": 15.8,
+      "end": 16.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " covering",
+      "start": 16.2,
+      "end": 16.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " those",
+      "start": 16.5,
+      "end": 16.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars.",
+      "start": 16.7,
+      "end": 17.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We're",
+      "start": 17.2,
+      "end": 17.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " good,",
+      "start": 17.4,
+      "end": 17.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Jonna.",
+      "start": 17.6,
+      "end": 17.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 17.9,
+      "end": 18,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 18.1,
+      "end": 18.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it.",
+      "start": 18.3,
+      "end": 18.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 19.1,
+      "end": 19.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " know",
+      "start": 19.3,
+      "end": 19.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 19.8,
+      "end": 20,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 20,
+      "end": 20.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 20.3,
+      "end": 20.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " close,",
+      "start": 21,
+      "end": 21.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 21.9,
+      "end": 22,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 22,
+      "end": 22.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 22.2,
+      "end": 22.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 22.4,
+      "end": 22.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " final",
+      "start": 23.1,
+      "end": 23.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " topic",
+      "start": 23.7,
+      "end": 24.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 24.1,
+      "end": 24.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " cover,",
+      "start": 24.3,
+      "end": 24.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " which",
+      "start": 24.9,
+      "end": 25.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 25.1,
+      "end": 25.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bringing",
+      "start": 25.4,
+      "end": 26,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 26.2,
+      "end": 26.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " five",
+      "start": 26.7,
+      "end": 27,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 27.1,
+      "end": 27.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 27.3,
+      "end": 27.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars",
+      "start": 27.6,
+      "end": 28,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 28,
+      "end": 28.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 28.2,
+      "end": 28.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 28.4,
+      "end": 28.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 28.7,
+      "end": 28.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 29,
+      "end": 29.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 29.1,
+      "end": 29.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together.",
+      "start": 29.8,
+      "end": 30.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Because",
+      "start": 31.2,
+      "end": 31.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 31.4,
+      "end": 31.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " real",
+      "start": 31.7,
+      "end": 32.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " power",
+      "start": 32.2,
+      "end": 32.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 32.8,
+      "end": 33.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 33.3,
+      "end": 33.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 33.7,
+      "end": 34.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 34.6,
+      "end": 34.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 34.8,
+      "end": 35,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 35,
+      "end": 35.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 35.4,
+      "end": 36,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillar.",
+      "start": 36,
+      "end": 36.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 36.9,
+      "end": 37.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 37.1,
+      "end": 37.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 37.6,
+      "end": 37.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars",
+      "start": 37.9,
+      "end": 38.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fit",
+      "start": 38.5,
+      "end": 38.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 38.9,
+      "end": 39.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 39.4,
+      "end": 40.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sync",
+      "start": 40.5,
+      "end": 40.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together",
+      "start": 41.1,
+      "end": 41.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 41.9,
+      "end": 42.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " create",
+      "start": 42.1,
+      "end": 42.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 42.5,
+      "end": 43,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " cohesive",
+      "start": 43.3,
+      "end": 44.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 44.4,
+      "end": 44.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 44.8,
+      "end": 45,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 45,
+      "end": 45.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 45.1,
+      "end": 45.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 45.7,
+      "end": 46,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " runs",
+      "start": 46,
+      "end": 46.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 46.8,
+      "end": 47,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " day",
+      "start": 47,
+      "end": 47.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 47.4,
+      "end": 47.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " day",
+      "start": 47.6,
+      "end": 47.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 48,
+      "end": 48.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 48.3,
+      "end": 48.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 48.6,
+      "end": 49,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 49.2,
+      "end": 49.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 49.3,
+      "end": 49.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 49.4,
+      "end": 49.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 49.6,
+      "end": 49.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 49.8,
+      "end": 50,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " some",
+      "start": 50,
+      "end": 50.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 50.3,
+      "end": 50.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here",
+      "start": 50.6,
+      "end": 50.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 50.8,
+      "end": 51,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 51.1,
+      "end": 51.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dive",
+      "start": 51.2,
+      "end": 51.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 51.5,
+      "end": 51.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " little",
+      "start": 51.7,
+      "end": 52.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bit",
+      "start": 52.1,
+      "end": 52.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " deeper",
+      "start": 52.3,
+      "end": 52.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 52.9,
+      "end": 53.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 53.2,
+      "end": 53.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 53.5,
+      "end": 53.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 53.9,
+      "end": 54,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 54,
+      "end": 54.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 54.2,
+      "end": 54.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars",
+      "start": 54.5,
+      "end": 54.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 55.1,
+      "end": 55.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 55.7,
+      "end": 56,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " play",
+      "start": 56,
+      "end": 56.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together",
+      "start": 56.4,
+      "end": 56.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 57.1,
+      "end": 57.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " give",
+      "start": 57.4,
+      "end": 57.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 57.7,
+      "end": 57.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 57.9,
+      "end": 58,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tactical",
+      "start": 58,
+      "end": 58.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 58.7,
+      "end": 59.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 59.1,
+      "end": 59.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 59.3,
+      "end": 59.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 59.4,
+      "end": 59.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 59.6,
+      "end": 59.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " understand",
+      "start": 59.8,
+      "end": 60.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " firsthand",
+      "start": 60.4,
+      "end": 61.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 61.7,
+      "end": 62,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " having",
+      "start": 62.1,
+      "end": 62.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 62.6,
+      "end": 62.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " new",
+      "start": 62.9,
+      "end": 63.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 63.5,
+      "end": 64,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " running",
+      "start": 64.1,
+      "end": 64.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 64.4,
+      "end": 64.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 64.8,
+      "end": 65,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business",
+      "start": 65,
+      "end": 65.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 65.4,
+      "end": 65.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 65.6,
+      "end": 65.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " five",
+      "start": 65.9,
+      "end": 66.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars",
+      "start": 66.3,
+      "end": 66.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " firing",
+      "start": 67,
+      "end": 67.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 67.6,
+      "end": 67.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 67.8,
+      "end": 68.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " cylinders",
+      "start": 68.1,
+      "end": 68.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 69.1,
+      "end": 69.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 69.3,
+      "end": 69.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 69.5,
+      "end": 69.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 69.6,
+      "end": 69.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " absolutely",
+      "start": 69.9,
+      "end": 70.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " transformative.",
+      "start": 70.7,
+      "end": 71.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 71.8,
+      "end": 72.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 72.1,
+      "end": 72.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 72.3,
+      "end": 72.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 72.4,
+      "end": 72.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bear",
+      "start": 72.6,
+      "end": 72.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 72.9,
+      "end": 73.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me,",
+      "start": 73.1,
+      "end": 73.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 73.5,
+      "end": 73.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 73.7,
+      "end": 74,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 74,
+      "end": 74.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " final",
+      "start": 74.5,
+      "end": 74.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " topic",
+      "start": 74.9,
+      "end": 75.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 75.5,
+      "end": 75.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " cover",
+      "start": 75.6,
+      "end": 75.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together.",
+      "start": 75.9,
+      "end": 76.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 76.6,
+      "end": 76.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then",
+      "start": 76.8,
+      "end": 77.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 77.2,
+      "end": 77.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " am",
+      "start": 77.4,
+      "end": 77.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 77.6,
+      "end": 77.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 77.8,
+      "end": 77.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " walk",
+      "start": 78,
+      "end": 78.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 78.3,
+      "end": 78.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " through",
+      "start": 78.4,
+      "end": 78.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " building",
+      "start": 78.8,
+      "end": 79.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 79.3,
+      "end": 79.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 79.5,
+      "end": 79.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " finalizing",
+      "start": 79.8,
+      "end": 80.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 80.8,
+      "end": 81,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tangible",
+      "start": 81,
+      "end": 81.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " deliverable",
+      "start": 81.7,
+      "end": 82.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 82.6,
+      "end": 82.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 82.8,
+      "end": 83.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 83.1,
+      "end": 83.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 83.3,
+      "end": 83.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information,",
+      "start": 83.5,
+      "end": 84.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " which",
+      "start": 84.2,
+      "end": 84.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 84.4,
+      "end": 84.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 84.5,
+      "end": 84.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 84.7,
+      "end": 84.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 84.9,
+      "end": 85,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 85.1,
+      "end": 85.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " finished",
+      "start": 85.3,
+      "end": 85.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 85.9,
+      "end": 86.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 86.6,
+      "end": 86.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 86.9,
+      "end": 87.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 87.1,
+      "end": 87.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 87.4,
+      "end": 87.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 87.8,
+      "end": 88,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth.",
+      "start": 88,
+      "end": 88.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 88.6,
+      "end": 88.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " let's",
+      "start": 89.1,
+      "end": 89.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dive",
+      "start": 89.5,
+      "end": 89.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 89.9,
+      "end": 90.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 90.1,
+      "end": 90.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " by",
+      "start": 90.2,
+      "end": 90.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " starting",
+      "start": 90.4,
+      "end": 91,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 91.1,
+      "end": 91.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 91.4,
+      "end": 91.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tangible,",
+      "start": 91.5,
+      "end": 92,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 92.1,
+      "end": 92.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tactical",
+      "start": 92.2,
+      "end": 92.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 92.9,
+      "end": 93.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " about",
+      "start": 93.8,
+      "end": 94.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 94.1,
+      "end": 94.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 94.3,
+      "end": 94.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 94.7,
+      "end": 94.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 94.9,
+      "end": 95.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " core",
+      "start": 95.2,
+      "end": 95.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars",
+      "start": 95.4,
+      "end": 95.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 95.9,
+      "end": 96.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 96.1,
+      "end": 96.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 96.2,
+      "end": 96.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 96.5,
+      "end": 96.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 96.7,
+      "end": 96.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 96.8,
+      "end": 97.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 97.4,
+      "end": 97.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together",
+      "start": 97.7,
+      "end": 98.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " seamlessly",
+      "start": 98.4,
+      "end": 99.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 99.2,
+      "end": 99.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 99.4,
+      "end": 99.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " background",
+      "start": 99.5,
+      "end": 100,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 100.2,
+      "end": 100.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " create",
+      "start": 100.4,
+      "end": 100.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 100.8,
+      "end": 101.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " maximally",
+      "start": 101.6,
+      "end": 102.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " efficient",
+      "start": 102.3,
+      "end": 102.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 102.8,
+      "end": 103.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 103.4,
+      "end": 103.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 103.6,
+      "end": 103.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 104.1,
+      "end": 104.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 104.3,
+      "end": 104.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 104.4,
+      "end": 104.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 104.6,
+      "end": 105,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " The",
+      "start": 105.4,
+      "end": 105.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 105.6,
+      "end": 106.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 106.1,
+      "end": 106.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 106.3,
+      "end": 106.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 106.5,
+      "end": 106.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 106.7,
+      "end": 106.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " use",
+      "start": 106.9,
+      "end": 107.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 107.4,
+      "end": 107.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 107.7,
+      "end": 108,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding,",
+      "start": 108.1,
+      "end": 108.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 108.8,
+      "end": 109.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " traditionally",
+      "start": 109.1,
+      "end": 109.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 110,
+      "end": 110.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 110.3,
+      "end": 110.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 110.8,
+      "end": 111,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 111,
+      "end": 111.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " mess",
+      "start": 111.1,
+      "end": 111.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 112,
+      "end": 112.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 112.3,
+      "end": 112.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " about",
+      "start": 112.6,
+      "end": 112.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 112.9,
+      "end": 113.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business",
+      "start": 113.1,
+      "end": 113.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I've",
+      "start": 113.5,
+      "end": 113.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ever",
+      "start": 113.6,
+      "end": 113.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " looked",
+      "start": 113.8,
+      "end": 114,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 114,
+      "end": 114.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 114.2,
+      "end": 114.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worked",
+      "start": 114.3,
+      "end": 114.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with.",
+      "start": 114.6,
+      "end": 114.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Why?",
+      "start": 115.1,
+      "end": 115.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Because",
+      "start": 115.7,
+      "end": 116,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 116,
+      "end": 116.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 116.2,
+      "end": 116.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " complicated.",
+      "start": 116.6,
+      "end": 117.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It",
+      "start": 117.6,
+      "end": 117.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " requires",
+      "start": 117.7,
+      "end": 118.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 118.2,
+      "end": 118.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " many",
+      "start": 118.4,
+      "end": 118.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 118.7,
+      "end": 118.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " steps",
+      "start": 118.9,
+      "end": 119.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " from",
+      "start": 119.6,
+      "end": 119.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 119.9,
+      "end": 120.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " many",
+      "start": 120.1,
+      "end": 120.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 120.4,
+      "end": 120.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " people",
+      "start": 120.7,
+      "end": 121,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 121.2,
+      "end": 121.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " need",
+      "start": 121.4,
+      "end": 121.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 121.5,
+      "end": 121.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " happen",
+      "start": 121.6,
+      "end": 121.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 121.9,
+      "end": 122,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " really",
+      "start": 122.1,
+      "end": 122.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tight",
+      "start": 122.5,
+      "end": 122.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " order",
+      "start": 122.8,
+      "end": 123.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 123.2,
+      "end": 123.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 123.5,
+      "end": 123.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 123.6,
+      "end": 123.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 123.8,
+      "end": 123.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 124,
+      "end": 124.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 124.3,
+      "end": 124.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " quickly",
+      "start": 124.4,
+      "end": 124.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 124.8,
+      "end": 124.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " possible.",
+      "start": 124.9,
+      "end": 125.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 125.7,
+      "end": 125.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " any",
+      "start": 126,
+      "end": 126.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " mistake",
+      "start": 126.4,
+      "end": 127.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pisses",
+      "start": 127.6,
+      "end": 128.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 128.1,
+      "end": 128.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 128.4,
+      "end": 128.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 128.5,
+      "end": 129,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 129.2,
+      "end": 129.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " really",
+      "start": 129.5,
+      "end": 129.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " incurs",
+      "start": 130,
+      "end": 130.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 130.4,
+      "end": 130.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 130.5,
+      "end": 130.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " real",
+      "start": 130.7,
+      "end": 131,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " risk",
+      "start": 131.1,
+      "end": 131.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 131.6,
+      "end": 131.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 131.9,
+      "end": 132.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " might",
+      "start": 132.1,
+      "end": 132.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " leave,",
+      "start": 132.4,
+      "end": 132.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right?",
+      "start": 133,
+      "end": 133.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Like",
+      "start": 133.2,
+      "end": 133.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " mistakes",
+      "start": 133.4,
+      "end": 134.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 134.1,
+      "end": 134.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 134.3,
+      "end": 134.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 134.7,
+      "end": 135.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " totally",
+      "start": 135.6,
+      "end": 136.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " destroy",
+      "start": 136.3,
+      "end": 136.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 137.1,
+      "end": 137.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trust",
+      "start": 137.5,
+      "end": 137.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 137.9,
+      "end": 138,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 138,
+      "end": 138.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " experience.",
+      "start": 138.4,
+      "end": 139.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 139.3,
+      "end": 139.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 139.5,
+      "end": 139.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " know",
+      "start": 139.7,
+      "end": 140.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 140.3,
+      "end": 140.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " much",
+      "start": 140.7,
+      "end": 141,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 141,
+      "end": 141.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " costs",
+      "start": 141.3,
+      "end": 141.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " us",
+      "start": 141.9,
+      "end": 142.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 142.4,
+      "end": 142.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 142.6,
+      "end": 142.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form",
+      "start": 142.7,
+      "end": 143,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 143,
+      "end": 143.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lower",
+      "start": 143.2,
+      "end": 143.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 143.6,
+      "end": 144,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lifetime",
+      "start": 144.2,
+      "end": 144.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " value.",
+      "start": 144.8,
+      "end": 145.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 145.6,
+      "end": 145.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 145.8,
+      "end": 146.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 146.2,
+      "end": 146.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 146.6,
+      "end": 146.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 146.7,
+      "end": 146.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " great",
+      "start": 146.8,
+      "end": 147,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 147.1,
+      "end": 147.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 147.4,
+      "end": 147.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 147.7,
+      "end": 147.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " super",
+      "start": 148,
+      "end": 148.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hard",
+      "start": 148.4,
+      "end": 148.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 148.7,
+      "end": 148.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 148.8,
+      "end": 149,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " well",
+      "start": 149,
+      "end": 149.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 149.6,
+      "end": 149.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 149.8,
+      "end": 150,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " super",
+      "start": 150.1,
+      "end": 150.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " high",
+      "start": 150.7,
+      "end": 151.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stakes.",
+      "start": 151.3,
+      "end": 151.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 152.3,
+      "end": 152.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " let's",
+      "start": 152.5,
+      "end": 152.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " talk",
+      "start": 152.9,
+      "end": 153.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " about",
+      "start": 153.2,
+      "end": 153.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 153.7,
+      "end": 154.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 154.1,
+      "end": 154.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 154.3,
+      "end": 154.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " use",
+      "start": 154.5,
+      "end": 154.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 155,
+      "end": 155.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 155.1,
+      "end": 155.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 155.5,
+      "end": 155.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 155.8,
+      "end": 155.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 155.9,
+      "end": 156.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " once",
+      "start": 156.3,
+      "end": 156.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 156.5,
+      "end": 156.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 156.7,
+      "end": 157,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " built",
+      "start": 157,
+      "end": 157.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 157.3,
+      "end": 157.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 157.8,
+      "end": 158.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " make",
+      "start": 158.1,
+      "end": 158.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 158.5,
+      "end": 158.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 158.9,
+      "end": 159.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 159.4,
+      "end": 159.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 159.6,
+      "end": 159.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fast,",
+      "start": 159.9,
+      "end": 160.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 160.8,
+      "end": 161,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 161,
+      "end": 161.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " frictionless,",
+      "start": 161.4,
+      "end": 162.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 162.4,
+      "end": 162.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " actually",
+      "start": 162.7,
+      "end": 163.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fully",
+      "start": 163.6,
+      "end": 164,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automated.",
+      "start": 164.6,
+      "end": 165.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 165.7,
+      "end": 165.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " mentioned",
+      "start": 165.9,
+      "end": 166.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 166.4,
+      "end": 166.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 166.6,
+      "end": 166.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 166.8,
+      "end": 166.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ran",
+      "start": 167,
+      "end": 167.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 167.3,
+      "end": 167.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " digital",
+      "start": 167.5,
+      "end": 167.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " marketing",
+      "start": 167.8,
+      "end": 168.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " agency,",
+      "start": 168.2,
+      "end": 168.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 168.9,
+      "end": 169.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 169.1,
+      "end": 169.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 169.3,
+      "end": 169.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " two",
+      "start": 169.9,
+      "end": 170,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 170.1,
+      "end": 170.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " four",
+      "start": 170.2,
+      "end": 170.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " clients",
+      "start": 170.4,
+      "end": 170.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 170.8,
+      "end": 170.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " day,",
+      "start": 170.9,
+      "end": 171.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 171.4,
+      "end": 171.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 171.6,
+      "end": 171.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 171.8,
+      "end": 172.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 172.7,
+      "end": 173.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " happened",
+      "start": 173.7,
+      "end": 174.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 174.2,
+      "end": 174.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " autopilot,",
+      "start": 174.6,
+      "end": 175.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meaning",
+      "start": 175.2,
+      "end": 175.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 175.5,
+      "end": 175.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " did",
+      "start": 175.8,
+      "end": 176,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 176,
+      "end": 176.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " look",
+      "start": 176.3,
+      "end": 176.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 176.6,
+      "end": 176.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 176.8,
+      "end": 177,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " once.",
+      "start": 177.1,
+      "end": 177.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 177.7,
+      "end": 177.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trusted",
+      "start": 177.9,
+      "end": 178.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 178.7,
+      "end": 178.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 178.9,
+      "end": 179.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 179.5,
+      "end": 179.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " run",
+      "start": 179.8,
+      "end": 180.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 180.1,
+      "end": 180.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " incredibly",
+      "start": 180.3,
+      "end": 181,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " complicated",
+      "start": 181,
+      "end": 181.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " multi-step",
+      "start": 181.6,
+      "end": 182.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 182.3,
+      "end": 182.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " without",
+      "start": 183,
+      "end": 183.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me.",
+      "start": 183.4,
+      "end": 183.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 183.9,
+      "end": 184.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " did",
+      "start": 184.2,
+      "end": 184.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 184.3,
+      "end": 184.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " look",
+      "start": 184.5,
+      "end": 184.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like?",
+      "start": 184.7,
+      "end": 184.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It",
+      "start": 185.2,
+      "end": 185.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " looked",
+      "start": 185.3,
+      "end": 185.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " something",
+      "start": 185.5,
+      "end": 185.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 185.8,
+      "end": 186,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this.",
+      "start": 186.1,
+      "end": 186.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 186.9,
+      "end": 187.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 187.4,
+      "end": 187.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 187.6,
+      "end": 187.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 187.8,
+      "end": 187.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " new",
+      "start": 187.8,
+      "end": 188,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client.",
+      "start": 188,
+      "end": 188.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Our",
+      "start": 188.5,
+      "end": 188.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " closer",
+      "start": 188.6,
+      "end": 188.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hopped",
+      "start": 188.9,
+      "end": 189.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 189.1,
+      "end": 189.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 189.2,
+      "end": 189.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " call",
+      "start": 189.3,
+      "end": 189.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 189.4,
+      "end": 189.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 189.6,
+      "end": 189.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 189.7,
+      "end": 189.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " closed",
+      "start": 189.9,
+      "end": 190.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them.",
+      "start": 190.1,
+      "end": 190.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Fantastic.",
+      "start": 190.4,
+      "end": 191.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " As",
+      "start": 191.5,
+      "end": 191.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " soon",
+      "start": 191.8,
+      "end": 192.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 192.2,
+      "end": 192.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 192.5,
+      "end": 192.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 192.7,
+      "end": 192.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hopped",
+      "start": 193,
+      "end": 193.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 193.2,
+      "end": 193.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 193.3,
+      "end": 193.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " call,",
+      "start": 193.4,
+      "end": 193.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 193.9,
+      "end": 194.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 194.2,
+      "end": 194.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " next",
+      "start": 194.6,
+      "end": 194.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " step",
+      "start": 194.9,
+      "end": 195.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 195.4,
+      "end": 195.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 195.6,
+      "end": 195.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 195.7,
+      "end": 195.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 195.9,
+      "end": 196.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " closer",
+      "start": 196.2,
+      "end": 196.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 196.8,
+      "end": 197,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fill",
+      "start": 197,
+      "end": 197.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 197.2,
+      "end": 197.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 197.4,
+      "end": 197.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 197.5,
+      "end": 197.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " called",
+      "start": 197.6,
+      "end": 197.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 198,
+      "end": 198.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 198.1,
+      "end": 198.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 198.8,
+      "end": 199.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form.",
+      "start": 199.4,
+      "end": 199.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " You've",
+      "start": 200.4,
+      "end": 200.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 200.6,
+      "end": 200.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 200.8,
+      "end": 201,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form",
+      "start": 201,
+      "end": 201.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 201.4,
+      "end": 201.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 201.6,
+      "end": 201.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 201.9,
+      "end": 202,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 202,
+      "end": 202.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " critical",
+      "start": 202.1,
+      "end": 202.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 202.5,
+      "end": 203.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " about",
+      "start": 203.1,
+      "end": 203.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 203.6,
+      "end": 203.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 203.7,
+      "end": 204.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 204.2,
+      "end": 204.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " everything",
+      "start": 204.4,
+      "end": 204.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 205,
+      "end": 205.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 205.1,
+      "end": 205.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 205.3,
+      "end": 205.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " end",
+      "start": 205.7,
+      "end": 206,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 206,
+      "end": 206.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " needs",
+      "start": 206.4,
+      "end": 207.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 207.3,
+      "end": 207.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " order",
+      "start": 207.5,
+      "end": 207.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 207.8,
+      "end": 208,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 208,
+      "end": 208.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " able",
+      "start": 208.2,
+      "end": 208.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 208.5,
+      "end": 208.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fulfill",
+      "start": 208.7,
+      "end": 209.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 209.2,
+      "end": 209.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 209.5,
+      "end": 209.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 209.7,
+      "end": 210,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " service",
+      "start": 210,
+      "end": 210.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " successfully.",
+      "start": 210.6,
+      "end": 211.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 211.7,
+      "end": 211.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " beautiful.",
+      "start": 211.9,
+      "end": 212.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " The",
+      "start": 212.5,
+      "end": 212.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " closer",
+      "start": 212.6,
+      "end": 213,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fills",
+      "start": 213.1,
+      "end": 213.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 213.5,
+      "end": 213.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 213.7,
+      "end": 213.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 213.8,
+      "end": 214,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 214.1,
+      "end": 214.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form.",
+      "start": 214.5,
+      "end": 214.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 214.9,
+      "end": 215.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 215.1,
+      "end": 215.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 215.3,
+      "end": 215.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " added",
+      "start": 215.4,
+      "end": 215.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " benefit",
+      "start": 215.8,
+      "end": 216.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 216.4,
+      "end": 216.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " making",
+      "start": 216.6,
+      "end": 216.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sure",
+      "start": 216.9,
+      "end": 217.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 217.1,
+      "end": 217.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 217.2,
+      "end": 217.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 217.4,
+      "end": 217.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " end",
+      "start": 217.7,
+      "end": 217.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 217.8,
+      "end": 218.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 218.3,
+      "end": 218.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " never",
+      "start": 218.5,
+      "end": 218.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bothering",
+      "start": 218.9,
+      "end": 219.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 219.7,
+      "end": 219.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sales",
+      "start": 219.9,
+      "end": 220.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 220.3,
+      "end": 220.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 220.8,
+      "end": 221,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 221.1,
+      "end": 221.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sales",
+      "start": 221.2,
+      "end": 221.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 221.5,
+      "end": 221.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 221.7,
+      "end": 221.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " handing",
+      "start": 221.9,
+      "end": 222.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 222.4,
+      "end": 222.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 222.7,
+      "end": 223,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 223.1,
+      "end": 223.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 223.2,
+      "end": 223.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " critical",
+      "start": 223.3,
+      "end": 223.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 223.6,
+      "end": 224.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 224.6,
+      "end": 225.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 225.8,
+      "end": 226,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 226.1,
+      "end": 226.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 226.2,
+      "end": 226.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " end",
+      "start": 226.4,
+      "end": 226.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team.",
+      "start": 226.7,
+      "end": 227,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 227.2,
+      "end": 227.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 227.4,
+      "end": 227.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " never",
+      "start": 227.5,
+      "end": 227.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 227.8,
+      "end": 227.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 227.9,
+      "end": 227.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 228,
+      "end": 228.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 228.3,
+      "end": 228.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 228.7,
+      "end": 228.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sales",
+      "start": 228.9,
+      "end": 229.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 229.4,
+      "end": 229.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bother",
+      "start": 229.6,
+      "end": 229.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 230,
+      "end": 230.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 230.2,
+      "end": 230.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 230.2,
+      "end": 230.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " middle",
+      "start": 230.3,
+      "end": 230.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 230.5,
+      "end": 230.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 230.7,
+      "end": 230.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " important",
+      "start": 230.9,
+      "end": 231.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " day",
+      "start": 231.3,
+      "end": 231.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " taking",
+      "start": 231.6,
+      "end": 231.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " calls",
+      "start": 231.9,
+      "end": 232.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 232.6,
+      "end": 232.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ask",
+      "start": 232.8,
+      "end": 233.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " where",
+      "start": 233.4,
+      "end": 233.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 233.6,
+      "end": 233.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 233.7,
+      "end": 233.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 233.8,
+      "end": 233.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 233.9,
+      "end": 234,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 234,
+      "end": 234.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 234.1,
+      "end": 234.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 234.4,
+      "end": 234.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 234.5,
+      "end": 234.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " did",
+      "start": 234.6,
+      "end": 234.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 234.7,
+      "end": 234.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 234.9,
+      "end": 235.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " agree",
+      "start": 235.1,
+      "end": 235.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 235.4,
+      "end": 235.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 235.5,
+      "end": 235.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what's",
+      "start": 235.6,
+      "end": 235.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 235.8,
+      "end": 235.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " payment",
+      "start": 235.9,
+      "end": 236.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " plan?",
+      "start": 236.2,
+      "end": 236.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " All",
+      "start": 236.9,
+      "end": 237.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 237.1,
+      "end": 237.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 237.2,
+      "end": 237.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 237.4,
+      "end": 237.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " added",
+      "start": 237.6,
+      "end": 238,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 238,
+      "end": 238.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 238.4,
+      "end": 238.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form.",
+      "start": 238.5,
+      "end": 238.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " OK,",
+      "start": 239,
+      "end": 239.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " beautiful.",
+      "start": 239.3,
+      "end": 239.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 239.9,
+      "end": 240.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 240.2,
+      "end": 240.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form",
+      "start": 240.3,
+      "end": 240.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 240.8,
+      "end": 240.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 240.9,
+      "end": 241.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " kicked",
+      "start": 241.1,
+      "end": 241.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 241.5,
+      "end": 241.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 242.2,
+      "end": 242.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 242.4,
+      "end": 243,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 243.1,
+      "end": 243.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automation.",
+      "start": 243.7,
+      "end": 244.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " From",
+      "start": 244.7,
+      "end": 245,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 245,
+      "end": 245.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form,",
+      "start": 245.2,
+      "end": 245.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " two",
+      "start": 245.7,
+      "end": 246,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 246,
+      "end": 246.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " happened.",
+      "start": 246.3,
+      "end": 246.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Number",
+      "start": 246.8,
+      "end": 247,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one,",
+      "start": 247.1,
+      "end": 247.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 247.7,
+      "end": 247.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 247.9,
+      "end": 248.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 248.6,
+      "end": 248.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 249.3,
+      "end": 249.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " duplicated",
+      "start": 249.7,
+      "end": 250.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 250.3,
+      "end": 250.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " assigned.",
+      "start": 250.5,
+      "end": 251,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " When",
+      "start": 251.3,
+      "end": 251.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 251.5,
+      "end": 251.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 251.6,
+      "end": 251.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " small,",
+      "start": 251.8,
+      "end": 252.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 252.2,
+      "end": 252.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 252.5,
+      "end": 252.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " literally",
+      "start": 252.7,
+      "end": 253.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 253.1,
+      "end": 253.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 253.4,
+      "end": 253.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " VA",
+      "start": 253.5,
+      "end": 253.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 254.2,
+      "end": 254.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 254.4,
+      "end": 254.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 254.7,
+      "end": 255.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 255.1,
+      "end": 255.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " new",
+      "start": 255.3,
+      "end": 255.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 255.9,
+      "end": 256.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 256.2,
+      "end": 256.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form",
+      "start": 256.7,
+      "end": 256.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " came",
+      "start": 256.9,
+      "end": 257.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 257.1,
+      "end": 257.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 257.2,
+      "end": 257.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 257.3,
+      "end": 257.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 257.4,
+      "end": 257.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 257.6,
+      "end": 257.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notification",
+      "start": 257.8,
+      "end": 258.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 258.3,
+      "end": 258.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Slack,",
+      "start": 258.5,
+      "end": 258.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 259.2,
+      "end": 259.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 259.3,
+      "end": 259.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 259.5,
+      "end": 259.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 259.7,
+      "end": 259.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 260,
+      "end": 260.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 260.1,
+      "end": 260.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 260.6,
+      "end": 260.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " inside",
+      "start": 261.1,
+      "end": 261.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 261.5,
+      "end": 261.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 261.6,
+      "end": 261.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 261.8,
+      "end": 262.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " warehouse.",
+      "start": 262.2,
+      "end": 262.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " They",
+      "start": 263.1,
+      "end": 263.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 263.3,
+      "end": 263.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " duplicate",
+      "start": 263.6,
+      "end": 264.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 264.6,
+      "end": 265,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " checklist",
+      "start": 265.1,
+      "end": 265.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 265.9,
+      "end": 266.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " template.",
+      "start": 266.4,
+      "end": 267,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " They",
+      "start": 267.4,
+      "end": 267.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 267.6,
+      "end": 267.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " assign",
+      "start": 267.8,
+      "end": 268.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 268.6,
+      "end": 268.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " relevant",
+      "start": 268.7,
+      "end": 269.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " account",
+      "start": 269.1,
+      "end": 269.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " manager,",
+      "start": 269.4,
+      "end": 269.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 270,
+      "end": 270.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " relevant",
+      "start": 270.1,
+      "end": 270.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " media",
+      "start": 270.4,
+      "end": 270.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " buyer,",
+      "start": 270.7,
+      "end": 271,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 271,
+      "end": 271.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 271.1,
+      "end": 271.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fulfillment",
+      "start": 271.6,
+      "end": 272.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 272.1,
+      "end": 272.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 272.4,
+      "end": 272.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 272.7,
+      "end": 272.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 272.8,
+      "end": 273.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 273.2,
+      "end": 273.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " needed",
+      "start": 273.3,
+      "end": 273.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 273.6,
+      "end": 273.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 273.7,
+      "end": 273.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " present",
+      "start": 273.8,
+      "end": 274.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 274.1,
+      "end": 274.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 274.2,
+      "end": 274.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 274.4,
+      "end": 274.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process.",
+      "start": 274.8,
+      "end": 275.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " They",
+      "start": 275.6,
+      "end": 275.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 275.7,
+      "end": 275.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " assign",
+      "start": 275.8,
+      "end": 276.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 276.1,
+      "end": 276.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 276.3,
+      "end": 276.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 276.5,
+      "end": 276.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " task.",
+      "start": 276.8,
+      "end": 277.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " They",
+      "start": 277.4,
+      "end": 277.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 277.6,
+      "end": 277.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " set",
+      "start": 277.7,
+      "end": 277.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 277.9,
+      "end": 277.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " due",
+      "start": 278,
+      "end": 278.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " date",
+      "start": 278.1,
+      "end": 278.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 278.5,
+      "end": 278.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 278.7,
+      "end": 279,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 279,
+      "end": 279.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " task,",
+      "start": 279.4,
+      "end": 279.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right?",
+      "start": 280.1,
+      "end": 280.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 280.5,
+      "end": 280.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " whether",
+      "start": 280.7,
+      "end": 280.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 280.9,
+      "end": 281.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " happens",
+      "start": 281.1,
+      "end": 281.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " manually",
+      "start": 281.4,
+      "end": 281.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 281.9,
+      "end": 282.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 282.2,
+      "end": 282.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 282.3,
+      "end": 282.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 282.4,
+      "end": 282.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 282.5,
+      "end": 282.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " make",
+      "start": 282.5,
+      "end": 282.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 282.7,
+      "end": 282.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fancy,",
+      "start": 282.8,
+      "end": 283.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 283.2,
+      "end": 283.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 283.3,
+      "end": 283.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 283.4,
+      "end": 283.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 283.5,
+      "end": 283.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically.",
+      "start": 283.7,
+      "end": 284.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " The",
+      "start": 284.8,
+      "end": 284.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 285,
+      "end": 285.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 285.5,
+      "end": 285.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 286,
+      "end": 286.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " duplicated",
+      "start": 286.2,
+      "end": 286.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 286.8,
+      "end": 286.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " assigned",
+      "start": 286.9,
+      "end": 287.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out.",
+      "start": 287.3,
+      "end": 287.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Beautiful.",
+      "start": 287.8,
+      "end": 288.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 288.2,
+      "end": 288.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " happened",
+      "start": 288.3,
+      "end": 288.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then?",
+      "start": 288.6,
+      "end": 288.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " All",
+      "start": 289.3,
+      "end": 289.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 289.6,
+      "end": 289.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " those",
+      "start": 289.8,
+      "end": 290,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tasks",
+      "start": 290,
+      "end": 290.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 290.7,
+      "end": 290.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pushed",
+      "start": 291,
+      "end": 291.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 291.6,
+      "end": 291.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " people's",
+      "start": 291.8,
+      "end": 292.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 292.3,
+      "end": 292.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to-do",
+      "start": 292.8,
+      "end": 293.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists.",
+      "start": 293.1,
+      "end": 293.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 293.8,
+      "end": 293.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " again,",
+      "start": 294,
+      "end": 294.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 294.3,
+      "end": 294.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " haven't",
+      "start": 294.5,
+      "end": 294.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " seen",
+      "start": 295,
+      "end": 295.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 295.3,
+      "end": 295.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " thing.",
+      "start": 295.4,
+      "end": 295.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 295.8,
+      "end": 296,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 296.1,
+      "end": 296.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 296.3,
+      "end": 296.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notification",
+      "start": 296.4,
+      "end": 297.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " coming",
+      "start": 297.1,
+      "end": 297.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 297.3,
+      "end": 297.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Slack",
+      "start": 297.5,
+      "end": 297.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 298.1,
+      "end": 298.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 298.3,
+      "end": 298.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " little",
+      "start": 298.4,
+      "end": 298.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hooray",
+      "start": 298.6,
+      "end": 298.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sign",
+      "start": 299,
+      "end": 299.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 299.4,
+      "end": 299.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 299.5,
+      "end": 299.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 299.6,
+      "end": 299.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 299.8,
+      "end": 299.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in.",
+      "start": 299.9,
+      "end": 300,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " new",
+      "start": 300,
+      "end": 300.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client.",
+      "start": 300.1,
+      "end": 300.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 300.8,
+      "end": 300.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 301,
+      "end": 301.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 301.1,
+      "end": 301.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " know",
+      "start": 301.4,
+      "end": 301.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 302,
+      "end": 302.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 302.2,
+      "end": 302.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 302.4,
+      "end": 303.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 303.1,
+      "end": 303.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 303.3,
+      "end": 303.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 303.7,
+      "end": 303.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " has",
+      "start": 303.9,
+      "end": 304,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " been",
+      "start": 304,
+      "end": 304.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notified.",
+      "start": 304.2,
+      "end": 304.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " They",
+      "start": 304.9,
+      "end": 305,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 305.1,
+      "end": 305.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " know",
+      "start": 305.3,
+      "end": 305.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 305.5,
+      "end": 306,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 306,
+      "end": 306.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tasks",
+      "start": 306.3,
+      "end": 306.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 306.7,
+      "end": 306.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 306.9,
+      "end": 307.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " need",
+      "start": 307.1,
+      "end": 307.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 307.3,
+      "end": 307.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 307.4,
+      "end": 307.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done",
+      "start": 307.5,
+      "end": 307.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " by",
+      "start": 307.7,
+      "end": 307.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 307.9,
+      "end": 308.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " date.",
+      "start": 308.2,
+      "end": 308.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 308.7,
+      "end": 308.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 308.9,
+      "end": 309.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 309.2,
+      "end": 309.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " those",
+      "start": 309.3,
+      "end": 309.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tasks",
+      "start": 309.5,
+      "end": 309.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 309.9,
+      "end": 310.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sitting",
+      "start": 310.1,
+      "end": 310.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 310.5,
+      "end": 310.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 310.6,
+      "end": 310.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 310.8,
+      "end": 311.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to-do",
+      "start": 311.3,
+      "end": 311.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists,",
+      "start": 311.6,
+      "end": 312,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 312.1,
+      "end": 312.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " waiting",
+      "start": 312.4,
+      "end": 312.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 312.8,
+      "end": 312.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 312.9,
+      "end": 313.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done",
+      "start": 313.1,
+      "end": 313.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 313.6,
+      "end": 313.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 313.9,
+      "end": 314,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " appropriate",
+      "start": 314,
+      "end": 314.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " deadline.",
+      "start": 314.5,
+      "end": 314.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Gorgeous.",
+      "start": 315.3,
+      "end": 315.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 316,
+      "end": 316.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 316.2,
+      "end": 316.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 316.3,
+      "end": 316.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 316.5,
+      "end": 316.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trust",
+      "start": 316.6,
+      "end": 317.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 317.3,
+      "end": 317.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 317.5,
+      "end": 317.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 317.8,
+      "end": 318.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 318.3,
+      "end": 318.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 318.5,
+      "end": 318.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 318.7,
+      "end": 318.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 318.9,
+      "end": 319.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarded",
+      "start": 319.2,
+      "end": 319.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " seamlessly.",
+      "start": 320.2,
+      "end": 321,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 321.9,
+      "end": 322,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " also",
+      "start": 322.1,
+      "end": 322.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " know",
+      "start": 322.4,
+      "end": 322.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 322.8,
+      "end": 323,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 323.1,
+      "end": 323.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " any",
+      "start": 323.2,
+      "end": 323.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 323.5,
+      "end": 324,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " member",
+      "start": 324,
+      "end": 324.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 324.3,
+      "end": 324.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 324.4,
+      "end": 324.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 324.6,
+      "end": 324.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " gets",
+      "start": 325,
+      "end": 325.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stuck",
+      "start": 325.2,
+      "end": 325.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 325.8,
+      "end": 326,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " blocked",
+      "start": 326,
+      "end": 326.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 326.5,
+      "end": 326.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 326.6,
+      "end": 326.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 326.7,
+      "end": 327,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 327.1,
+      "end": 327.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " gets",
+      "start": 327.8,
+      "end": 328.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 328.3,
+      "end": 328.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " track",
+      "start": 328.7,
+      "end": 329.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 329.2,
+      "end": 329.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " slowed",
+      "start": 329.4,
+      "end": 329.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down,",
+      "start": 329.9,
+      "end": 330.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then",
+      "start": 330.6,
+      "end": 330.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " those",
+      "start": 330.9,
+      "end": 331.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " issues",
+      "start": 331.2,
+      "end": 331.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 331.6,
+      "end": 331.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 331.7,
+      "end": 331.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 331.9,
+      "end": 332,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 332,
+      "end": 332.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " raised",
+      "start": 332.3,
+      "end": 332.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 332.7,
+      "end": 332.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 332.9,
+      "end": 333.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " added",
+      "start": 333.8,
+      "end": 334.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 334.5,
+      "end": 334.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 334.9,
+      "end": 335.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 335.2,
+      "end": 335.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " success",
+      "start": 335.6,
+      "end": 336,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " huddle.",
+      "start": 336.1,
+      "end": 336.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We",
+      "start": 336.6,
+      "end": 336.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 336.8,
+      "end": 336.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 336.9,
+      "end": 337,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " quick",
+      "start": 337,
+      "end": 337.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " huddle",
+      "start": 337.3,
+      "end": 337.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 337.5,
+      "end": 337.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 337.8,
+      "end": 338.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " day.",
+      "start": 338.1,
+      "end": 338.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 338.7,
+      "end": 338.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 338.9,
+      "end": 339.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " 24",
+      "start": 339.1,
+      "end": 339.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hours,",
+      "start": 339.6,
+      "end": 340,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 340,
+      "end": 340.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " knew",
+      "start": 340.2,
+      "end": 340.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 340.4,
+      "end": 340.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 340.5,
+      "end": 340.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 340.7,
+      "end": 341.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " block",
+      "start": 341.1,
+      "end": 341.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 341.4,
+      "end": 341.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 341.5,
+      "end": 341.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 341.7,
+      "end": 341.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " become",
+      "start": 341.8,
+      "end": 342.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " unblocked",
+      "start": 342.2,
+      "end": 342.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 343,
+      "end": 343.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 343.1,
+      "end": 343.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 343.3,
+      "end": 343.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 343.7,
+      "end": 343.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 343.9,
+      "end": 344.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 344.1,
+      "end": 344.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 344.5,
+      "end": 344.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " track.",
+      "start": 344.7,
+      "end": 345.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 345.3,
+      "end": 345.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " again,",
+      "start": 345.5,
+      "end": 345.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 346,
+      "end": 346.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 346.3,
+      "end": 346.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 346.4,
+      "end": 346.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 346.7,
+      "end": 346.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " without",
+      "start": 346.8,
+      "end": 347.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " any",
+      "start": 347.3,
+      "end": 347.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " input",
+      "start": 347.9,
+      "end": 348.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " from",
+      "start": 348.4,
+      "end": 348.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me.",
+      "start": 348.7,
+      "end": 349,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 349.1,
+      "end": 349.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " said",
+      "start": 349.2,
+      "end": 349.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 349.4,
+      "end": 349.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 349.5,
+      "end": 349.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 349.7,
+      "end": 349.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " two",
+      "start": 349.8,
+      "end": 350.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 350.1,
+      "end": 350.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 350.5,
+      "end": 350.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fired",
+      "start": 350.8,
+      "end": 351.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 351.5,
+      "end": 351.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 351.8,
+      "end": 351.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 351.9,
+      "end": 352.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " initial",
+      "start": 352.1,
+      "end": 352.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 352.4,
+      "end": 352.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form.",
+      "start": 352.8,
+      "end": 353.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 353.1,
+      "end": 353.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 353.2,
+      "end": 353.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " first",
+      "start": 353.4,
+      "end": 353.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 353.7,
+      "end": 353.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 353.9,
+      "end": 354,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 354.1,
+      "end": 354.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 354.6,
+      "end": 354.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 354.7,
+      "end": 354.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " workflow",
+      "start": 354.9,
+      "end": 355.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 355.6,
+      "end": 355.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ensured",
+      "start": 355.9,
+      "end": 356.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 356.2,
+      "end": 356.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 356.4,
+      "end": 356.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarded",
+      "start": 356.8,
+      "end": 357.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 357.2,
+      "end": 357.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 357.4,
+      "end": 357.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " directly.",
+      "start": 357.7,
+      "end": 358.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " The",
+      "start": 358.6,
+      "end": 358.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " second",
+      "start": 358.9,
+      "end": 359.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 359.5,
+      "end": 359.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 359.7,
+      "end": 359.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 359.9,
+      "end": 360.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " flow.",
+      "start": 360.8,
+      "end": 361.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 361.4,
+      "end": 361.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 361.7,
+      "end": 362,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 362,
+      "end": 362.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 362.2,
+      "end": 362.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 362.3,
+      "end": 363,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 363,
+      "end": 363.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 363.1,
+      "end": 363.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " taken",
+      "start": 363.3,
+      "end": 363.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 363.6,
+      "end": 363.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 363.8,
+      "end": 363.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 363.9,
+      "end": 364.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 364.1,
+      "end": 364.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 364.4,
+      "end": 364.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " form",
+      "start": 364.8,
+      "end": 365.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 365.4,
+      "end": 365.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 365.7,
+      "end": 366.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " populated",
+      "start": 366.4,
+      "end": 367.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 367.5,
+      "end": 368,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 368,
+      "end": 368.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 368.3,
+      "end": 368.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 369,
+      "end": 369.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboard.",
+      "start": 369.7,
+      "end": 370.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Master",
+      "start": 370.4,
+      "end": 370.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboard,",
+      "start": 370.8,
+      "end": 371.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 371.3,
+      "end": 371.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 371.5,
+      "end": 371.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 371.9,
+      "end": 372.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tracker",
+      "start": 372.3,
+      "end": 372.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 373,
+      "end": 373.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 373.2,
+      "end": 373.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 373.5,
+      "end": 374.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " updated.",
+      "start": 374.2,
+      "end": 374.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 374.9,
+      "end": 375,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 375,
+      "end": 375.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 375.2,
+      "end": 375.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 375.4,
+      "end": 375.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 375.5,
+      "end": 375.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " new",
+      "start": 375.7,
+      "end": 375.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 375.8,
+      "end": 376.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 376.1,
+      "end": 376.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 376.3,
+      "end": 376.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there.",
+      "start": 376.4,
+      "end": 376.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 376.8,
+      "end": 376.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 376.9,
+      "end": 377,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 377,
+      "end": 377.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 377.2,
+      "end": 377.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 377.5,
+      "end": 377.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " relevant",
+      "start": 377.6,
+      "end": 377.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 377.9,
+      "end": 378.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 378.5,
+      "end": 378.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 378.7,
+      "end": 378.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client,",
+      "start": 378.9,
+      "end": 379.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 379.5,
+      "end": 379.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " billing",
+      "start": 379.7,
+      "end": 380.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " email",
+      "start": 380.1,
+      "end": 380.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 380.5,
+      "end": 380.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 380.7,
+      "end": 380.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " address",
+      "start": 380.9,
+      "end": 381.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 381.3,
+      "end": 381.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 381.5,
+      "end": 381.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " name",
+      "start": 381.6,
+      "end": 381.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 381.8,
+      "end": 381.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 381.9,
+      "end": 382.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dog,",
+      "start": 382.1,
+      "end": 382.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " whatever",
+      "start": 382.5,
+      "end": 383,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 383,
+      "end": 383.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " important",
+      "start": 383.2,
+      "end": 383.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 383.8,
+      "end": 384.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 384.7,
+      "end": 384.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 384.9,
+      "end": 385,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 385.1,
+      "end": 385.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 385.2,
+      "end": 385.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 385.4,
+      "end": 385.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " success",
+      "start": 385.7,
+      "end": 386,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 386.1,
+      "end": 386.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 386.3,
+      "end": 386.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see,",
+      "start": 386.4,
+      "end": 386.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 387,
+      "end": 387.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 387.2,
+      "end": 387.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 387.4,
+      "end": 388.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " added",
+      "start": 388.1,
+      "end": 388.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 388.6,
+      "end": 388.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 388.9,
+      "end": 389,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 389.1,
+      "end": 389.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tracker.",
+      "start": 389.5,
+      "end": 389.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " As",
+      "start": 389.9,
+      "end": 390.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 390.2,
+      "end": 390.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 390.4,
+      "end": 390.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " moved",
+      "start": 390.8,
+      "end": 391.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " through",
+      "start": 391.2,
+      "end": 391.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 391.5,
+      "end": 391.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 391.7,
+      "end": 392.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 392.3,
+      "end": 392.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 392.9,
+      "end": 393,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " went",
+      "start": 393,
+      "end": 393.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " from",
+      "start": 393.2,
+      "end": 393.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 393.6,
+      "end": 394,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " started",
+      "start": 394.1,
+      "end": 394.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 394.7,
+      "end": 395,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 395,
+      "end": 395.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " finalized",
+      "start": 395.5,
+      "end": 396.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 396.1,
+      "end": 396.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " launch,",
+      "start": 396.3,
+      "end": 396.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 397.1,
+      "end": 397.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " status",
+      "start": 397.4,
+      "end": 398,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 398,
+      "end": 398.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 398.3,
+      "end": 398.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 398.4,
+      "end": 398.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tracker",
+      "start": 398.7,
+      "end": 399.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 399.3,
+      "end": 399.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " change",
+      "start": 399.6,
+      "end": 400,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 400.3,
+      "end": 400.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 400.5,
+      "end": 400.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 400.7,
+      "end": 401,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 401,
+      "end": 401.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " glance,",
+      "start": 401.2,
+      "end": 401.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 401.7,
+      "end": 401.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 401.9,
+      "end": 402,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 402,
+      "end": 402.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 402.2,
+      "end": 402.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 402.5,
+      "end": 402.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 402.6,
+      "end": 402.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 402.9,
+      "end": 403.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tracker.",
+      "start": 403.2,
+      "end": 403.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 403.6,
+      "end": 403.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 403.7,
+      "end": 403.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 403.9,
+      "end": 404.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 404.1,
+      "end": 404.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 404.7,
+      "end": 404.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " many",
+      "start": 404.9,
+      "end": 405.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " clients",
+      "start": 405.3,
+      "end": 405.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 405.7,
+      "end": 405.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 405.8,
+      "end": 406,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 406,
+      "end": 406.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 406.2,
+      "end": 406.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 406.7,
+      "end": 407.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 407.3,
+      "end": 407.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 407.5,
+      "end": 407.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " where",
+      "start": 407.9,
+      "end": 408.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 408.2,
+      "end": 408.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 408.3,
+      "end": 408.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 408.4,
+      "end": 408.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 408.9,
+      "end": 409.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were.",
+      "start": 409.1,
+      "end": 409.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 410,
+      "end": 410.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 410.2,
+      "end": 410.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboard",
+      "start": 410.4,
+      "end": 410.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " offered",
+      "start": 410.9,
+      "end": 411.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 411.3,
+      "end": 411.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " real",
+      "start": 411.6,
+      "end": 411.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 411.9,
+      "end": 412.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " visibility",
+      "start": 412.2,
+      "end": 412.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 413,
+      "end": 413.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 413.5,
+      "end": 413.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 413.7,
+      "end": 414.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 414.3,
+      "end": 414.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 414.4,
+      "end": 414.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ever",
+      "start": 414.5,
+      "end": 414.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " cared",
+      "start": 414.7,
+      "end": 415,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 415,
+      "end": 415.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " jump",
+      "start": 415.1,
+      "end": 415.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 415.4,
+      "end": 415.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 415.5,
+      "end": 415.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 415.9,
+      "end": 416.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 416.1,
+      "end": 416.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 416.3,
+      "end": 416.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " look.",
+      "start": 416.4,
+      "end": 416.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Between",
+      "start": 416.9,
+      "end": 417.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 417.2,
+      "end": 417.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 417.4,
+      "end": 417.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me,",
+      "start": 417.5,
+      "end": 417.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 417.9,
+      "end": 418.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " never",
+      "start": 418.1,
+      "end": 418.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " did",
+      "start": 418.4,
+      "end": 418.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 418.9,
+      "end": 419,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 419,
+      "end": 419.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " never",
+      "start": 419.2,
+      "end": 419.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 419.5,
+      "end": 419.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 419.7,
+      "end": 420,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 420.2,
+      "end": 420.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 420.5,
+      "end": 420.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trusted",
+      "start": 420.6,
+      "end": 421.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 421.2,
+      "end": 421.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 421.4,
+      "end": 421.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 421.6,
+      "end": 421.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 422,
+      "end": 422.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 422.1,
+      "end": 422.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 422.3,
+      "end": 422.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " manage",
+      "start": 422.4,
+      "end": 422.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 422.7,
+      "end": 422.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 422.9,
+      "end": 423.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 423.3,
+      "end": 423.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 423.9,
+      "end": 424.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me.",
+      "start": 424.2,
+      "end": 424.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 424.6,
+      "end": 424.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 424.8,
+      "end": 424.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " added",
+      "start": 424.9,
+      "end": 425.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " even",
+      "start": 425.2,
+      "end": 425.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 425.5,
+      "end": 425.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " more",
+      "start": 425.8,
+      "end": 426.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " step,",
+      "start": 426.1,
+      "end": 426.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " which",
+      "start": 426.6,
+      "end": 426.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 426.8,
+      "end": 426.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 426.9,
+      "end": 427.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 427.1,
+      "end": 427.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 427.3,
+      "end": 427.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 427.5,
+      "end": 427.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 427.9,
+      "end": 428.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notified",
+      "start": 428.5,
+      "end": 429,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 429.2,
+      "end": 429.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 429.5,
+      "end": 429.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 429.6,
+      "end": 430.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 430.1,
+      "end": 430.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " blocked",
+      "start": 430.3,
+      "end": 430.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 430.8,
+      "end": 430.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " overdue.",
+      "start": 431,
+      "end": 431.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 431.6,
+      "end": 431.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 431.8,
+      "end": 431.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 431.9,
+      "end": 432,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notified",
+      "start": 432.1,
+      "end": 432.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " via",
+      "start": 432.5,
+      "end": 432.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 432.8,
+      "end": 432.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting,",
+      "start": 432.9,
+      "end": 433.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 433.3,
+      "end": 433.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 433.4,
+      "end": 433.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " telling",
+      "start": 433.7,
+      "end": 434,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 434,
+      "end": 434.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 434.2,
+      "end": 434.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 434.3,
+      "end": 434.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 434.4,
+      "end": 434.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " some",
+      "start": 434.6,
+      "end": 434.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " issue,",
+      "start": 434.9,
+      "end": 435.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 435.5,
+      "end": 435.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 435.8,
+      "end": 435.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 435.9,
+      "end": 436,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 436.1,
+      "end": 436.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notified",
+      "start": 436.2,
+      "end": 436.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 436.9,
+      "end": 437.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 437.2,
+      "end": 437.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 437.3,
+      "end": 437.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 437.7,
+      "end": 437.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " successfully",
+      "start": 437.8,
+      "end": 438.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarded.",
+      "start": 438.7,
+      "end": 439.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 439.2,
+      "end": 439.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " set",
+      "start": 439.3,
+      "end": 439.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 439.6,
+      "end": 439.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notifications",
+      "start": 439.7,
+      "end": 440.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 440.4,
+      "end": 440.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 440.5,
+      "end": 440.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project",
+      "start": 440.6,
+      "end": 440.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " management",
+      "start": 440.9,
+      "end": 441.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 441.3,
+      "end": 441.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 441.8,
+      "end": 442.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notify",
+      "start": 442.1,
+      "end": 442.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 442.6,
+      "end": 442.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 442.8,
+      "end": 443.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 443.4,
+      "end": 443.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " directly",
+      "start": 443.5,
+      "end": 444.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 444.4,
+      "end": 444.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 444.7,
+      "end": 444.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " major",
+      "start": 445,
+      "end": 445.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " milestones",
+      "start": 445.3,
+      "end": 445.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 445.8,
+      "end": 446,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 446,
+      "end": 446.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " track",
+      "start": 446.2,
+      "end": 446.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 446.7,
+      "end": 446.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 446.9,
+      "end": 447.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " track.",
+      "start": 447.1,
+      "end": 447.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 447.7,
+      "end": 447.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 447.9,
+      "end": 448.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meant",
+      "start": 448.1,
+      "end": 448.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 448.4,
+      "end": 448.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 448.5,
+      "end": 448.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 448.7,
+      "end": 448.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 448.8,
+      "end": 449,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 449,
+      "end": 449.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " able",
+      "start": 449.3,
+      "end": 449.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 449.6,
+      "end": 449.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " track",
+      "start": 449.8,
+      "end": 450.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 450.3,
+      "end": 450.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 450.5,
+      "end": 451.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 451.3,
+      "end": 451.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process.",
+      "start": 451.9,
+      "end": 452.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 452.6,
+      "end": 452.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 452.8,
+      "end": 453,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " measure",
+      "start": 453.1,
+      "end": 453.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 453.9,
+      "end": 454.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 454.6,
+      "end": 455,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " efficiently",
+      "start": 455,
+      "end": 455.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 455.6,
+      "end": 455.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " inefficiently",
+      "start": 455.8,
+      "end": 456.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 456.5,
+      "end": 456.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 456.7,
+      "end": 456.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " getting",
+      "start": 456.8,
+      "end": 457,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 457.1,
+      "end": 457.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done.",
+      "start": 457.4,
+      "end": 457.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 458,
+      "end": 458.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 458.2,
+      "end": 458.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 458.4,
+      "end": 458.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 458.9,
+      "end": 459.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " which",
+      "start": 459.6,
+      "end": 459.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tasks",
+      "start": 459.9,
+      "end": 460.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 460.7,
+      "end": 460.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 460.9,
+      "end": 461,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ones",
+      "start": 461,
+      "end": 461.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 461.2,
+      "end": 461.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 461.3,
+      "end": 461.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " consistently",
+      "start": 461.5,
+      "end": 462.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " blocking",
+      "start": 462.6,
+      "end": 463,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " us",
+      "start": 463.1,
+      "end": 463.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 463.3,
+      "end": 463.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " holding",
+      "start": 463.4,
+      "end": 463.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " us",
+      "start": 463.9,
+      "end": 464.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up.",
+      "start": 464.2,
+      "end": 464.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 464.8,
+      "end": 464.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 465,
+      "end": 465.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " make",
+      "start": 465.2,
+      "end": 465.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ongoing",
+      "start": 465.5,
+      "end": 466.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 466.1,
+      "end": 466.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " continuous",
+      "start": 466.2,
+      "end": 466.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " improvements",
+      "start": 467,
+      "end": 467.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 468.1,
+      "end": 468.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 468.4,
+      "end": 468.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 468.7,
+      "end": 469.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 469.4,
+      "end": 469.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 469.6,
+      "end": 469.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 469.8,
+      "end": 470.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 470.1,
+      "end": 470.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 470.4,
+      "end": 470.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 470.7,
+      "end": 470.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarded",
+      "start": 470.9,
+      "end": 471.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 471.3,
+      "end": 471.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client,",
+      "start": 471.4,
+      "end": 471.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 472,
+      "end": 472.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 472.1,
+      "end": 472.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " slightly",
+      "start": 472.3,
+      "end": 472.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " better",
+      "start": 472.7,
+      "end": 473,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 473,
+      "end": 473.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " slightly",
+      "start": 473.2,
+      "end": 473.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " better",
+      "start": 473.5,
+      "end": 473.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 473.7,
+      "end": 473.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " slightly",
+      "start": 473.9,
+      "end": 474.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " better",
+      "start": 474.2,
+      "end": 474.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " until",
+      "start": 474.6,
+      "end": 474.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 474.9,
+      "end": 475,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 475.1,
+      "end": 475.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 475.7,
+      "end": 476.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 476.4,
+      "end": 476.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 476.7,
+      "end": 476.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fast",
+      "start": 477,
+      "end": 477.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 477.4,
+      "end": 477.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " efficient",
+      "start": 477.5,
+      "end": 477.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 477.9,
+      "end": 478.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automated",
+      "start": 478.2,
+      "end": 478.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 478.7,
+      "end": 478.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " streamlined",
+      "start": 478.8,
+      "end": 479.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 479.3,
+      "end": 479.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " possible.",
+      "start": 479.8,
+      "end": 480.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 480.5,
+      "end": 480.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 480.7,
+      "end": 480.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 480.8,
+      "end": 481.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 481.6,
+      "end": 481.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 481.8,
+      "end": 482,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 482.1,
+      "end": 482.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " warehouse",
+      "start": 482.7,
+      "end": 483.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pushing",
+      "start": 483.4,
+      "end": 483.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tasks",
+      "start": 483.8,
+      "end": 484.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 484.3,
+      "end": 484.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 484.6,
+      "end": 485.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to-do",
+      "start": 485.2,
+      "end": 485.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists",
+      "start": 485.5,
+      "end": 485.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 485.9,
+      "end": 486.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 486.1,
+      "end": 486.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " escalated",
+      "start": 486.7,
+      "end": 487.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 487.4,
+      "end": 487.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting",
+      "start": 487.7,
+      "end": 488,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " agendas",
+      "start": 488,
+      "end": 488.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 488.5,
+      "end": 488.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " necessary,",
+      "start": 488.7,
+      "end": 489.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 489.7,
+      "end": 489.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 489.9,
+      "end": 490,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 490.1,
+      "end": 490.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " backed",
+      "start": 490.3,
+      "end": 490.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " by",
+      "start": 490.9,
+      "end": 491.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 491.1,
+      "end": 491.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 491.3,
+      "end": 491.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " being",
+      "start": 491.9,
+      "end": 492.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tracked",
+      "start": 492.2,
+      "end": 492.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 492.6,
+      "end": 492.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " kept",
+      "start": 492.8,
+      "end": 493,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up",
+      "start": 493,
+      "end": 493.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 493.2,
+      "end": 493.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " date",
+      "start": 493.3,
+      "end": 493.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 493.6,
+      "end": 493.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 493.8,
+      "end": 494.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards,",
+      "start": 494.2,
+      "end": 494.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " aka",
+      "start": 495.3,
+      "end": 495.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 496.1,
+      "end": 496.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 496.4,
+      "end": 497.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 497.3,
+      "end": 497.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 497.6,
+      "end": 497.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 498,
+      "end": 498.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 498.1,
+      "end": 498.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 498.5,
+      "end": 499,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " working",
+      "start": 499.3,
+      "end": 499.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 499.8,
+      "end": 500.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " harmony,",
+      "start": 500.2,
+      "end": 500.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " working",
+      "start": 500.7,
+      "end": 501.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together.",
+      "start": 501.1,
+      "end": 501.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Allowed",
+      "start": 502.5,
+      "end": 502.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 503,
+      "end": 503.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 503.1,
+      "end": 503.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 503.2,
+      "end": 503.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 503.4,
+      "end": 503.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 503.5,
+      "end": 503.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 503.7,
+      "end": 503.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " most",
+      "start": 503.8,
+      "end": 504.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " complicated",
+      "start": 504.3,
+      "end": 505.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " processes,",
+      "start": 505.4,
+      "end": 506.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 506.1,
+      "end": 506.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 506.2,
+      "end": 506.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 506.3,
+      "end": 506.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " most",
+      "start": 506.4,
+      "end": 506.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " important",
+      "start": 506.6,
+      "end": 507.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " moments",
+      "start": 507.7,
+      "end": 508.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 508.2,
+      "end": 508.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 508.4,
+      "end": 508.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 508.7,
+      "end": 509,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " happiness",
+      "start": 509,
+      "end": 509.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " journey,",
+      "start": 509.5,
+      "end": 509.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 510.2,
+      "end": 510.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " put",
+      "start": 510.4,
+      "end": 510.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 510.6,
+      "end": 510.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 510.9,
+      "end": 511.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " autopilot",
+      "start": 511.3,
+      "end": 512,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 512.2,
+      "end": 512.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 512.5,
+      "end": 512.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " safety",
+      "start": 512.7,
+      "end": 513.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " net",
+      "start": 513.2,
+      "end": 513.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 513.4,
+      "end": 513.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " place",
+      "start": 513.6,
+      "end": 514,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 514.2,
+      "end": 514.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 514.4,
+      "end": 514.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 514.6,
+      "end": 514.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 514.9,
+      "end": 515,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " personally",
+      "start": 515.1,
+      "end": 515.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 515.5,
+      "end": 515.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " notified",
+      "start": 515.7,
+      "end": 516.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " only",
+      "start": 516.6,
+      "end": 517,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 517.1,
+      "end": 517.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 517.4,
+      "end": 517.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 517.6,
+      "end": 517.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 518,
+      "end": 518.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 518.2,
+      "end": 518.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 518.6,
+      "end": 518.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " problem.",
+      "start": 518.7,
+      "end": 519.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 519.5,
+      "end": 519.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 519.8,
+      "end": 520,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " could",
+      "start": 520,
+      "end": 520.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 520.2,
+      "end": 520.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 520.6,
+      "end": 520.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " analytics",
+      "start": 520.8,
+      "end": 521.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 521.5,
+      "end": 521.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 521.7,
+      "end": 522,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 522,
+      "end": 522.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " visibility",
+      "start": 522.1,
+      "end": 522.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 522.8,
+      "end": 523,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 523,
+      "end": 523.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 523.2,
+      "end": 523.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 524,
+      "end": 524.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " consistently",
+      "start": 524.2,
+      "end": 525.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " make",
+      "start": 525.2,
+      "end": 525.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " improvements",
+      "start": 525.6,
+      "end": 526.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 526.2,
+      "end": 526.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 526.3,
+      "end": 526.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 526.8,
+      "end": 527.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 527.3,
+      "end": 527.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time.",
+      "start": 527.5,
+      "end": 527.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Allowed",
+      "start": 528.1,
+      "end": 528.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " us",
+      "start": 528.4,
+      "end": 528.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 528.6,
+      "end": 528.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 528.7,
+      "end": 528.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 528.9,
+      "end": 528.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 529,
+      "end": 529.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 529.5,
+      "end": 529.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 529.8,
+      "end": 529.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " competitors",
+      "start": 529.9,
+      "end": 530.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 530.6,
+      "end": 530.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " generally",
+      "start": 530.7,
+      "end": 531.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " spending",
+      "start": 531.1,
+      "end": 531.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " between",
+      "start": 531.5,
+      "end": 531.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " seven",
+      "start": 531.9,
+      "end": 532.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 532.2,
+      "end": 532.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " 10",
+      "start": 532.4,
+      "end": 532.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " days",
+      "start": 532.8,
+      "end": 533.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on.",
+      "start": 533.2,
+      "end": 533.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 533.8,
+      "end": 534,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 534.1,
+      "end": 534.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 534.4,
+      "end": 534.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 534.8,
+      "end": 535.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 535.5,
+      "end": 535.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done",
+      "start": 535.7,
+      "end": 535.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 536,
+      "end": 536.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 536.3,
+      "end": 536.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 536.9,
+      "end": 537.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " two",
+      "start": 537.2,
+      "end": 537.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 537.7,
+      "end": 537.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " maximum",
+      "start": 537.8,
+      "end": 538.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " three",
+      "start": 538.4,
+      "end": 538.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " days.",
+      "start": 539,
+      "end": 539.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We",
+      "start": 539.8,
+      "end": 540,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " moved",
+      "start": 540,
+      "end": 540.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " faster",
+      "start": 540.5,
+      "end": 541,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 541.2,
+      "end": 541.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 541.5,
+      "end": 541.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team.",
+      "start": 541.6,
+      "end": 541.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We",
+      "start": 541.8,
+      "end": 542,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " moved",
+      "start": 542,
+      "end": 542.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " more",
+      "start": 542.3,
+      "end": 542.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " efficiently",
+      "start": 542.5,
+      "end": 543.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 543.5,
+      "end": 543.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 543.8,
+      "end": 543.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team.",
+      "start": 543.9,
+      "end": 544.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We",
+      "start": 544.2,
+      "end": 544.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 544.3,
+      "end": 544.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " spending",
+      "start": 544.5,
+      "end": 544.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 544.9,
+      "end": 545.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 545.1,
+      "end": 545.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " doing",
+      "start": 545.8,
+      "end": 546,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 546,
+      "end": 546.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " most",
+      "start": 546.2,
+      "end": 546.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " important",
+      "start": 546.7,
+      "end": 547.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work,",
+      "start": 547.2,
+      "end": 547.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " namely",
+      "start": 547.6,
+      "end": 547.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " onboarding",
+      "start": 548,
+      "end": 548.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 548.4,
+      "end": 548.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 548.5,
+      "end": 548.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 548.8,
+      "end": 548.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " getting",
+      "start": 548.9,
+      "end": 549.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 549.2,
+      "end": 549.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " live",
+      "start": 549.3,
+      "end": 549.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 549.6,
+      "end": 549.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " give",
+      "start": 549.8,
+      "end": 549.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 549.9,
+      "end": 550.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 550.1,
+      "end": 550.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wow",
+      "start": 550.3,
+      "end": 550.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " experience.",
+      "start": 550.7,
+      "end": 551.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 551.7,
+      "end": 551.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 551.9,
+      "end": 552,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 552,
+      "end": 552.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " spending",
+      "start": 552.2,
+      "end": 552.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " none",
+      "start": 552.6,
+      "end": 552.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 552.9,
+      "end": 553,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 553.1,
+      "end": 553.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 553.2,
+      "end": 553.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trying",
+      "start": 553.9,
+      "end": 554.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 554.3,
+      "end": 554.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " track",
+      "start": 554.3,
+      "end": 554.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down",
+      "start": 554.6,
+      "end": 554.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information,",
+      "start": 554.8,
+      "end": 555.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trying",
+      "start": 555.6,
+      "end": 555.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 556,
+      "end": 556,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " figure",
+      "start": 556.1,
+      "end": 556.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 556.3,
+      "end": 556.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " where",
+      "start": 556.4,
+      "end": 556.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 556.6,
+      "end": 556.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 556.7,
+      "end": 556.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 556.8,
+      "end": 557.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 557.2,
+      "end": 557.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were,",
+      "start": 557.4,
+      "end": 557.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trying",
+      "start": 557.9,
+      "end": 558.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 558.3,
+      "end": 558.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pick",
+      "start": 558.4,
+      "end": 558.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up",
+      "start": 558.5,
+      "end": 558.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dropped",
+      "start": 558.7,
+      "end": 559,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " balls",
+      "start": 559,
+      "end": 559.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 559.4,
+      "end": 559.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 559.5,
+      "end": 559.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 559.7,
+      "end": 559.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 559.8,
+      "end": 560,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 560,
+      "end": 560.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dropped,",
+      "start": 560.2,
+      "end": 560.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " trying",
+      "start": 560.8,
+      "end": 561.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 561.1,
+      "end": 561.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fight",
+      "start": 561.2,
+      "end": 561.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 561.4,
+      "end": 561.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fire",
+      "start": 561.5,
+      "end": 561.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 561.9,
+      "end": 562.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " somebody",
+      "start": 562.1,
+      "end": 562.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " forgot",
+      "start": 562.4,
+      "end": 562.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 562.7,
+      "end": 562.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " task",
+      "start": 562.8,
+      "end": 563.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 563.2,
+      "end": 563.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 563.3,
+      "end": 563.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 563.5,
+      "end": 563.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 563.6,
+      "end": 563.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " was",
+      "start": 563.8,
+      "end": 564,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pissed.",
+      "start": 564,
+      "end": 564.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " None",
+      "start": 565.1,
+      "end": 565.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 565.5,
+      "end": 565.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 565.7,
+      "end": 566,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " happened",
+      "start": 566.1,
+      "end": 566.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 567,
+      "end": 567.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 567.4,
+      "end": 567.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 567.7,
+      "end": 568.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ensured",
+      "start": 568.4,
+      "end": 569.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 569.4,
+      "end": 569.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 569.6,
+      "end": 569.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right",
+      "start": 569.7,
+      "end": 570,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 570,
+      "end": 570.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " got",
+      "start": 570.3,
+      "end": 570.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done",
+      "start": 570.7,
+      "end": 570.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 571.1,
+      "end": 571.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 571.9,
+      "end": 572.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " without",
+      "start": 572.1,
+      "end": 572.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me.",
+      "start": 572.4,
+      "end": 572.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Again,",
+      "start": 573.1,
+      "end": 573.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 573.4,
+      "end": 573.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 573.6,
+      "end": 573.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 573.7,
+      "end": 573.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 574,
+      "end": 574.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 574.3,
+      "end": 574.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 575,
+      "end": 575.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 575.2,
+      "end": 575.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 575.4,
+      "end": 575.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truly",
+      "start": 575.5,
+      "end": 576,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " working",
+      "start": 576,
+      "end": 576.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 576.4,
+      "end": 576.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 576.7,
+      "end": 576.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 576.9,
+      "end": 577,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 577,
+      "end": 577.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 577.5,
+      "end": 577.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 577.8,
+      "end": 578,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 578,
+      "end": 578.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 578.2,
+      "end": 578.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 578.5,
+      "end": 578.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 578.7,
+      "end": 578.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 578.9,
+      "end": 579.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 579.1,
+      "end": 579.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 579.4,
+      "end": 579.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team.",
+      "start": 579.7,
+      "end": 580,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 580.2,
+      "end": 580.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hope",
+      "start": 580.4,
+      "end": 580.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 580.7,
+      "end": 580.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 580.8,
+      "end": 581,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " illustrates",
+      "start": 581.1,
+      "end": 581.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 581.6,
+      "end": 581.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " power",
+      "start": 581.8,
+      "end": 582.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 582.6,
+      "end": 582.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 583,
+      "end": 583.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system.",
+      "start": 583.2,
+      "end": 583.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 583.6,
+      "end": 583.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 583.8,
+      "end": 583.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wanted",
+      "start": 583.9,
+      "end": 584.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 584.3,
+      "end": 584.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 584.4,
+      "end": 584.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 584.5,
+      "end": 584.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " moment",
+      "start": 584.6,
+      "end": 584.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 584.9,
+      "end": 585,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " talk",
+      "start": 585,
+      "end": 585.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 585.3,
+      "end": 585.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " through",
+      "start": 585.5,
+      "end": 585.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " an",
+      "start": 585.8,
+      "end": 586,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in-depth",
+      "start": 586.1,
+      "end": 586.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 586.6,
+      "end": 587,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 587,
+      "end": 587.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that,",
+      "start": 587.3,
+      "end": 587.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 587.9,
+      "end": 588.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 588.2,
+      "end": 588.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " reality",
+      "start": 588.4,
+      "end": 589.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 589.1,
+      "end": 589.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 589.9,
+      "end": 590.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 590.2,
+      "end": 590.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project",
+      "start": 590.6,
+      "end": 591.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 591.2,
+      "end": 591.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 591.7,
+      "end": 592.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work.",
+      "start": 592.4,
+      "end": 592.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It",
+      "start": 593.4,
+      "end": 593.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " takes",
+      "start": 593.7,
+      "end": 594.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 594.4,
+      "end": 594.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 595.1,
+      "end": 595.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " build",
+      "start": 595.4,
+      "end": 595.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 595.9,
+      "end": 596.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " maintain",
+      "start": 596.1,
+      "end": 596.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 596.8,
+      "end": 597,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 597,
+      "end": 597.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 597.4,
+      "end": 597.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 597.7,
+      "end": 597.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth.",
+      "start": 597.9,
+      "end": 598.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 598.2,
+      "end": 598.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 598.4,
+      "end": 598.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 598.5,
+      "end": 598.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 598.6,
+      "end": 598.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 598.8,
+      "end": 599.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 599.4,
+      "end": 599.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 599.6,
+      "end": 599.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 599.7,
+      "end": 599.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " turn.",
+      "start": 599.8,
+      "end": 600,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 600.1,
+      "end": 600.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 600.4,
+      "end": 600.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " around",
+      "start": 600.9,
+      "end": 601.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 601.4,
+      "end": 601.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 601.6,
+      "end": 601.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 601.8,
+      "end": 602.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 602.1,
+      "end": 602.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 602.2,
+      "end": 602.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 602.3,
+      "end": 602.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 602.5,
+      "end": 602.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " centralize",
+      "start": 602.8,
+      "end": 603.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 603.4,
+      "end": 603.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 603.7,
+      "end": 603.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " populate",
+      "start": 603.9,
+      "end": 604.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 604.4,
+      "end": 604.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 604.5,
+      "end": 604.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pull",
+      "start": 604.6,
+      "end": 604.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 604.8,
+      "end": 605.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 605.1,
+      "end": 605.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 605.2,
+      "end": 605.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " information",
+      "start": 605.4,
+      "end": 605.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in.",
+      "start": 605.9,
+      "end": 606.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 606.5,
+      "end": 606.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 606.7,
+      "end": 606.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 606.8,
+      "end": 606.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 606.9,
+      "end": 607.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 607.1,
+      "end": 607.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 607.7,
+      "end": 607.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 607.9,
+      "end": 608,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 608,
+      "end": 608.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " keep",
+      "start": 608.1,
+      "end": 608.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " those",
+      "start": 608.5,
+      "end": 608.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 608.8,
+      "end": 609.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards",
+      "start": 609.2,
+      "end": 609.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up",
+      "start": 609.7,
+      "end": 609.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 609.9,
+      "end": 610,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " date.",
+      "start": 610,
+      "end": 610.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 610.5,
+      "end": 610.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 610.6,
+      "end": 610.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 610.8,
+      "end": 610.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 610.8,
+      "end": 611,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 611,
+      "end": 611.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 611.6,
+      "end": 611.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 611.8,
+      "end": 611.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 611.9,
+      "end": 612.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " change",
+      "start": 612.1,
+      "end": 612.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 612.6,
+      "end": 612.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " habits",
+      "start": 612.8,
+      "end": 613.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 613.3,
+      "end": 613.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 613.4,
+      "end": 613.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " behaviors",
+      "start": 613.6,
+      "end": 614.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 614.4,
+      "end": 614.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 614.6,
+      "end": 614.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 614.7,
+      "end": 614.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 614.9,
+      "end": 615.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " used",
+      "start": 615.1,
+      "end": 615.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 615.5,
+      "end": 615.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " using",
+      "start": 616.1,
+      "end": 616.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 616.6,
+      "end": 616.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 616.9,
+      "end": 617.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 617.4,
+      "end": 618,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 618,
+      "end": 618.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " way.",
+      "start": 618.3,
+      "end": 618.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I'm",
+      "start": 618.6,
+      "end": 618.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 618.7,
+      "end": 618.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 618.9,
+      "end": 619,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 619,
+      "end": 619.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lie",
+      "start": 619.1,
+      "end": 619.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 619.4,
+      "end": 619.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you.",
+      "start": 619.5,
+      "end": 619.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 620,
+      "end": 620.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hard.",
+      "start": 620.3,
+      "end": 620.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 621,
+      "end": 621.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 621.3,
+      "end": 621.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " important",
+      "start": 621.7,
+      "end": 622.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 622.3,
+      "end": 622.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " remember",
+      "start": 622.4,
+      "end": 623,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " why",
+      "start": 623.4,
+      "end": 623.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 624.5,
+      "end": 624.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worth",
+      "start": 624.8,
+      "end": 625.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 625.3,
+      "end": 625.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hard.",
+      "start": 625.6,
+      "end": 626,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Why",
+      "start": 626.7,
+      "end": 627.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 627.2,
+      "end": 627.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " makes",
+      "start": 627.3,
+      "end": 627.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 627.6,
+      "end": 627.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 627.7,
+      "end": 627.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 628,
+      "end": 628.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " life,",
+      "start": 628.2,
+      "end": 628.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 628.6,
+      "end": 628.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 628.8,
+      "end": 628.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team's",
+      "start": 628.9,
+      "end": 629.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " life",
+      "start": 629.3,
+      "end": 629.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " way",
+      "start": 629.9,
+      "end": 630.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " easier.",
+      "start": 630.2,
+      "end": 630.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Why",
+      "start": 631.3,
+      "end": 631.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 631.8,
+      "end": 631.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " makes",
+      "start": 631.9,
+      "end": 632.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 632.2,
+      "end": 632.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business",
+      "start": 632.3,
+      "end": 632.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " way",
+      "start": 633,
+      "end": 633.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " faster,",
+      "start": 633.4,
+      "end": 634,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " way",
+      "start": 634.2,
+      "end": 634.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " more",
+      "start": 634.4,
+      "end": 634.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " productive,",
+      "start": 634.6,
+      "end": 635.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " way",
+      "start": 635.4,
+      "end": 635.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " more",
+      "start": 635.6,
+      "end": 635.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " profitable.",
+      "start": 635.8,
+      "end": 636.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 637,
+      "end": 637.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " why",
+      "start": 637.3,
+      "end": 637.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 638,
+      "end": 638.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 638.3,
+      "end": 638.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 638.6,
+      "end": 638.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 638.8,
+      "end": 639,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " saved",
+      "start": 639,
+      "end": 639.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 639.5,
+      "end": 639.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 639.9,
+      "end": 640.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " energy,",
+      "start": 640.1,
+      "end": 640.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 640.8,
+      "end": 641.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 641.1,
+      "end": 641.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 641.3,
+      "end": 641.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " devote",
+      "start": 641.4,
+      "end": 641.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 641.9,
+      "end": 642.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 642.3,
+      "end": 642.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 642.4,
+      "end": 642.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 642.9,
+      "end": 643.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 643.2,
+      "end": 643.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 643.6,
+      "end": 643.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " highest",
+      "start": 643.8,
+      "end": 644.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " value",
+      "start": 644.6,
+      "end": 644.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " driving",
+      "start": 645,
+      "end": 645.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " activities",
+      "start": 645.3,
+      "end": 646,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 646.1,
+      "end": 646.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 646.3,
+      "end": 646.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 646.5,
+      "end": 646.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 646.8,
+      "end": 647,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " drive",
+      "start": 647,
+      "end": 647.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " growth",
+      "start": 647.6,
+      "end": 648,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 648.2,
+      "end": 648.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 649.1,
+      "end": 649.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " company.",
+      "start": 649.3,
+      "end": 649.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 650,
+      "end": 650.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " yes,",
+      "start": 650.3,
+      "end": 650.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 650.7,
+      "end": 650.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 650.9,
+      "end": 651.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hard.",
+      "start": 651.1,
+      "end": 651.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 651.8,
+      "end": 652,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " yes,",
+      "start": 652.1,
+      "end": 652.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 652.8,
+      "end": 652.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 653,
+      "end": 653.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " also",
+      "start": 653.2,
+      "end": 653.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " absolutely",
+      "start": 654,
+      "end": 654.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worth",
+      "start": 655,
+      "end": 655.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it.",
+      "start": 655.3,
+      "end": 655.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 656.4,
+      "end": 656.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 656.6,
+      "end": 656.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 656.8,
+      "end": 656.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 657,
+      "end": 657.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " being",
+      "start": 657.1,
+      "end": 657.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " said,",
+      "start": 657.4,
+      "end": 657.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " let's",
+      "start": 657.8,
+      "end": 658,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 658.1,
+      "end": 658.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bring",
+      "start": 658.7,
+      "end": 659.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 659.1,
+      "end": 659.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 659.4,
+      "end": 659.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together.",
+      "start": 659.7,
+      "end": 660.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Let's",
+      "start": 660.2,
+      "end": 660.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " click",
+      "start": 660.4,
+      "end": 660.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 660.6,
+      "end": 660.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 660.9,
+      "end": 661,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 661,
+      "end": 661.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worksheet",
+      "start": 661.1,
+      "end": 661.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 661.5,
+      "end": 661.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " build",
+      "start": 661.7,
+      "end": 662,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 662,
+      "end": 662.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " final",
+      "start": 662.3,
+      "end": 662.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 662.8,
+      "end": 663.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 663.5,
+      "end": 663.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 663.8,
+      "end": 664.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 664.5,
+      "end": 664.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 664.7,
+      "end": 664.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 664.9,
+      "end": 665.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 665.1,
+      "end": 665.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 665.3,
+      "end": 665.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 665.5,
+      "end": 665.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 666.2,
+      "end": 666.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 666.8,
+      "end": 667.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 667.1,
+      "end": 667.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 667.4,
+      "end": 667.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth.",
+      "start": 667.5,
+      "end": 667.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We",
+      "start": 668.3,
+      "end": 668.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " really",
+      "start": 668.6,
+      "end": 668.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 668.9,
+      "end": 669.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 669.1,
+      "end": 669.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 669.3,
+      "end": 669.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " end",
+      "start": 669.4,
+      "end": 669.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here.",
+      "start": 669.7,
+      "end": 670,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 670.1,
+      "end": 670.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " let's",
+      "start": 670.6,
+      "end": 670.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " bring",
+      "start": 670.9,
+      "end": 671.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 671.1,
+      "end": 671.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 671.4,
+      "end": 671.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 671.5,
+      "end": 671.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " together",
+      "start": 671.7,
+      "end": 672.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 672.1,
+      "end": 672.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " produce",
+      "start": 672.3,
+      "end": 672.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 672.7,
+      "end": 672.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " final",
+      "start": 672.9,
+      "end": 673.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 673.3,
+      "end": 673.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tangible",
+      "start": 673.4,
+      "end": 674,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " deliverable,",
+      "start": 674,
+      "end": 674.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " which",
+      "start": 674.9,
+      "end": 675.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 675.1,
+      "end": 675.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 675.5,
+      "end": 675.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " final",
+      "start": 676,
+      "end": 676.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline.",
+      "start": 676.5,
+      "end": 677,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 677.4,
+      "end": 677.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 677.6,
+      "end": 677.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 677.8,
+      "end": 678,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 678,
+      "end": 678.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " listed",
+      "start": 678.3,
+      "end": 678.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 678.8,
+      "end": 679.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " across",
+      "start": 679.1,
+      "end": 679.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 679.5,
+      "end": 679.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worksheet",
+      "start": 679.7,
+      "end": 680.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 680.4,
+      "end": 680.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 680.7,
+      "end": 680.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 680.8,
+      "end": 681.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " many",
+      "start": 681.2,
+      "end": 681.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things,",
+      "start": 681.4,
+      "end": 681.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 681.8,
+      "end": 682,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 682,
+      "end": 682.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 682.1,
+      "end": 682.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " many",
+      "start": 682.4,
+      "end": 682.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists,",
+      "start": 682.7,
+      "end": 683.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 683.2,
+      "end": 683.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 683.3,
+      "end": 683.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOPs,",
+      "start": 683.7,
+      "end": 684.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 684.5,
+      "end": 684.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 684.8,
+      "end": 684.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 685,
+      "end": 685.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stuff",
+      "start": 685.2,
+      "end": 685.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 686.1,
+      "end": 686.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 686.3,
+      "end": 686.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 686.5,
+      "end": 686.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 686.8,
+      "end": 687.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 687.2,
+      "end": 687.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 687.4,
+      "end": 687.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 687.7,
+      "end": 687.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 687.9,
+      "end": 688.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 688.1,
+      "end": 688.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have.",
+      "start": 688.3,
+      "end": 688.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " The",
+      "start": 688.8,
+      "end": 688.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " final",
+      "start": 688.9,
+      "end": 689.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " step",
+      "start": 689.2,
+      "end": 689.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 689.5,
+      "end": 689.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 689.7,
+      "end": 689.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 689.8,
+      "end": 690,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " reorganize",
+      "start": 690,
+      "end": 690.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 690.9,
+      "end": 691,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 691,
+      "end": 691.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 691.4,
+      "end": 691.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 691.6,
+      "end": 691.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 691.8,
+      "end": 692.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " comprehensive",
+      "start": 692.4,
+      "end": 693.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline.",
+      "start": 693.4,
+      "end": 693.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 694,
+      "end": 694.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 694.5,
+      "end": 694.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 694.8,
+      "end": 694.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " three",
+      "start": 694.8,
+      "end": 695,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " step",
+      "start": 695,
+      "end": 695.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 695.2,
+      "end": 695.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here.",
+      "start": 695.6,
+      "end": 695.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Step",
+      "start": 695.8,
+      "end": 696.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one,",
+      "start": 696.2,
+      "end": 696.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " decide",
+      "start": 696.9,
+      "end": 697.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 697.4,
+      "end": 697.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 697.6,
+      "end": 697.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder",
+      "start": 697.8,
+      "end": 698.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " structure",
+      "start": 698.2,
+      "end": 698.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 698.8,
+      "end": 699,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 699,
+      "end": 699.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 699.1,
+      "end": 699.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 699.5,
+      "end": 699.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organize",
+      "start": 699.9,
+      "end": 700.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " everything.",
+      "start": 700.3,
+      "end": 700.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 700.7,
+      "end": 700.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 700.9,
+      "end": 701,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 701,
+      "end": 701.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " macro",
+      "start": 701.3,
+      "end": 701.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder",
+      "start": 702.2,
+      "end": 702.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " structure.",
+      "start": 702.8,
+      "end": 703,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 703.1,
+      "end": 703.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 703.2,
+      "end": 703.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 703.2,
+      "end": 703.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " advise",
+      "start": 703.4,
+      "end": 703.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " having",
+      "start": 703.8,
+      "end": 704.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 704.1,
+      "end": 704.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder",
+      "start": 704.6,
+      "end": 704.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 704.9,
+      "end": 705.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 705.1,
+      "end": 705.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " department",
+      "start": 705.4,
+      "end": 705.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 706.1,
+      "end": 706.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " well",
+      "start": 706.3,
+      "end": 706.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 706.6,
+      "end": 707,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 707.2,
+      "end": 707.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " major",
+      "start": 707.7,
+      "end": 708.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product.",
+      "start": 708.3,
+      "end": 708.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 709.2,
+      "end": 709.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 709.4,
+      "end": 709.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 709.4,
+      "end": 709.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " only",
+      "start": 709.6,
+      "end": 709.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 709.8,
+      "end": 710,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 710.1,
+      "end": 710.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product,",
+      "start": 710.5,
+      "end": 711.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " maybe",
+      "start": 711.3,
+      "end": 711.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 711.6,
+      "end": 711.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " don't",
+      "start": 711.7,
+      "end": 711.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " need",
+      "start": 711.8,
+      "end": 712,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this.",
+      "start": 712,
+      "end": 712.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Maybe",
+      "start": 712.2,
+      "end": 712.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 712.3,
+      "end": 712.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 712.4,
+      "end": 712.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 712.5,
+      "end": 712.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 712.7,
+      "end": 712.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product",
+      "start": 712.7,
+      "end": 713,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder",
+      "start": 713,
+      "end": 713.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 713.3,
+      "end": 713.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then",
+      "start": 713.4,
+      "end": 713.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that's",
+      "start": 713.5,
+      "end": 713.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " everything",
+      "start": 713.8,
+      "end": 714.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " regarding",
+      "start": 714.1,
+      "end": 714.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 714.5,
+      "end": 714.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product.",
+      "start": 714.7,
+      "end": 715.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " But",
+      "start": 715.4,
+      "end": 715.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 715.5,
+      "end": 715.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 715.7,
+      "end": 715.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 715.9,
+      "end": 716.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 716.1,
+      "end": 716.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " couple",
+      "start": 716.3,
+      "end": 716.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 716.6,
+      "end": 716.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 716.8,
+      "end": 717.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tiers",
+      "start": 717.2,
+      "end": 717.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 718.1,
+      "end": 718.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " products",
+      "start": 718.6,
+      "end": 719,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 719,
+      "end": 719.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 719.1,
+      "end": 719.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " products",
+      "start": 719.3,
+      "end": 719.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 719.7,
+      "end": 719.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 719.8,
+      "end": 720.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOPs,",
+      "start": 720.2,
+      "end": 720.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 721,
+      "end": 721.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 721.3,
+      "end": 721.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " members",
+      "start": 721.6,
+      "end": 721.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " running",
+      "start": 722,
+      "end": 722.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them,",
+      "start": 722.3,
+      "end": 722.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then",
+      "start": 722.7,
+      "end": 722.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 722.9,
+      "end": 723,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 723,
+      "end": 723.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " recommend",
+      "start": 723.2,
+      "end": 723.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " taking",
+      "start": 724.1,
+      "end": 724.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 724.4,
+      "end": 724.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 724.6,
+      "end": 724.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " parent",
+      "start": 724.8,
+      "end": 725.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product",
+      "start": 725.2,
+      "end": 725.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder",
+      "start": 725.6,
+      "end": 725.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 726,
+      "end": 726.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " actually",
+      "start": 726.2,
+      "end": 726.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 726.6,
+      "end": 726.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " breaking",
+      "start": 726.8,
+      "end": 727.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 727.2,
+      "end": 727.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down",
+      "start": 727.4,
+      "end": 727.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 727.9,
+      "end": 728.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 728.3,
+      "end": 728.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " relevant",
+      "start": 728.4,
+      "end": 728.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " products",
+      "start": 728.8,
+      "end": 729.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 729.1,
+      "end": 729.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 729.3,
+      "end": 729.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 729.5,
+      "end": 729.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 729.6,
+      "end": 729.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business",
+      "start": 729.7,
+      "end": 730.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " offer.",
+      "start": 730.2,
+      "end": 730.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 730.9,
+      "end": 731,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 731,
+      "end": 731.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 731.1,
+      "end": 731.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 731.3,
+      "end": 731.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 731.5,
+      "end": 731.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 731.7,
+      "end": 732.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here",
+      "start": 732.2,
+      "end": 732.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 732.5,
+      "end": 732.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " step",
+      "start": 732.7,
+      "end": 733,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one.",
+      "start": 733.1,
+      "end": 733.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Again,",
+      "start": 733.6,
+      "end": 733.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we're",
+      "start": 733.9,
+      "end": 734.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 734.1,
+      "end": 734.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " overcomplicating",
+      "start": 734.2,
+      "end": 734.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this.",
+      "start": 734.8,
+      "end": 735.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 735.1,
+      "end": 735.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sales.",
+      "start": 735.3,
+      "end": 735.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 735.8,
+      "end": 735.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " marketing.",
+      "start": 736,
+      "end": 736.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 736.4,
+      "end": 736.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product",
+      "start": 736.5,
+      "end": 736.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " A.",
+      "start": 736.9,
+      "end": 736.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 737,
+      "end": 737.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product",
+      "start": 737.1,
+      "end": 737.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " B,",
+      "start": 737.4,
+      "end": 737.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right?",
+      "start": 737.6,
+      "end": 737.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Keep",
+      "start": 737.9,
+      "end": 738.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 738.1,
+      "end": 738.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 738.2,
+      "end": 738.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " simple,",
+      "start": 738.4,
+      "end": 738.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 739.1,
+      "end": 739.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individualize",
+      "start": 739.3,
+      "end": 740.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 740.1,
+      "end": 740.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 740.3,
+      "end": 740.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 740.5,
+      "end": 740.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 741,
+      "end": 741.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 741.2,
+      "end": 741.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 741.8,
+      "end": 742.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 742.1,
+      "end": 742.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 742.3,
+      "end": 742.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 742.4,
+      "end": 742.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " macro",
+      "start": 742.8,
+      "end": 743.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " structure",
+      "start": 743.3,
+      "end": 743.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 744.3,
+      "end": 744.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 744.4,
+      "end": 744.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 744.5,
+      "end": 744.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 744.7,
+      "end": 744.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organize",
+      "start": 744.9,
+      "end": 745.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 745.4,
+      "end": 745.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 745.6,
+      "end": 745.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 745.8,
+      "end": 746,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 746,
+      "end": 746.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 746.1,
+      "end": 746.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " under?",
+      "start": 746.4,
+      "end": 746.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Then",
+      "start": 747.5,
+      "end": 747.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " step",
+      "start": 748,
+      "end": 748.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " number",
+      "start": 748.2,
+      "end": 748.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " two",
+      "start": 748.5,
+      "end": 748.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 749.1,
+      "end": 749.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 749.2,
+      "end": 749.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 749.3,
+      "end": 749.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 749.4,
+      "end": 749.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 749.6,
+      "end": 749.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 749.7,
+      "end": 749.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 750,
+      "end": 750.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 750.5,
+      "end": 750.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 750.7,
+      "end": 750.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 750.8,
+      "end": 751.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " beginning",
+      "start": 751.1,
+      "end": 751.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 751.5,
+      "end": 751.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 751.8,
+      "end": 751.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worksheet.",
+      "start": 752,
+      "end": 752.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We're",
+      "start": 752.6,
+      "end": 752.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 752.7,
+      "end": 752.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 752.9,
+      "end": 753,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " look",
+      "start": 753.1,
+      "end": 753.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 753.4,
+      "end": 753.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 753.6,
+      "end": 753.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " brain",
+      "start": 753.8,
+      "end": 754.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dump",
+      "start": 754.4,
+      "end": 754.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 755.1,
+      "end": 755.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stuff",
+      "start": 755.4,
+      "end": 755.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 755.7,
+      "end": 755.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 755.9,
+      "end": 756,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " put",
+      "start": 756,
+      "end": 756.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 756.2,
+      "end": 756.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 756.4,
+      "end": 756.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 756.9,
+      "end": 757.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " page",
+      "start": 757.2,
+      "end": 757.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 757.5,
+      "end": 757.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 757.7,
+      "end": 757.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worksheet,",
+      "start": 757.9,
+      "end": 758.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 758.7,
+      "end": 758.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 758.8,
+      "end": 758.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 759,
+      "end": 759.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 759.1,
+      "end": 759.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 759.3,
+      "end": 759.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organize",
+      "start": 759.5,
+      "end": 760.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 760.1,
+      "end": 760.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 760.6,
+      "end": 761.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 761.3,
+      "end": 761.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " macro",
+      "start": 761.6,
+      "end": 761.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders,",
+      "start": 762.2,
+      "end": 762.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right?",
+      "start": 762.9,
+      "end": 763.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 763.5,
+      "end": 763.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " where",
+      "start": 763.9,
+      "end": 764.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 764.1,
+      "end": 764.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 764.2,
+      "end": 764.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 764.3,
+      "end": 764.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 764.5,
+      "end": 764.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 764.7,
+      "end": 764.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " warehouse?",
+      "start": 765.1,
+      "end": 765.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Not",
+      "start": 766,
+      "end": 766.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 766.2,
+      "end": 766.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " give",
+      "start": 766.3,
+      "end": 766.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 766.4,
+      "end": 766.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 766.5,
+      "end": 766.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " answer,",
+      "start": 766.6,
+      "end": 766.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 766.9,
+      "end": 767,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I'd",
+      "start": 767,
+      "end": 767.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " recommend",
+      "start": 767.2,
+      "end": 767.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 767.5,
+      "end": 767.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " put",
+      "start": 767.6,
+      "end": 767.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 767.8,
+      "end": 767.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " under",
+      "start": 768,
+      "end": 768.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operations.",
+      "start": 768.2,
+      "end": 769,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Where",
+      "start": 769.3,
+      "end": 769.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 769.5,
+      "end": 769.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 769.6,
+      "end": 769.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 769.7,
+      "end": 769.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 770,
+      "end": 770.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards?",
+      "start": 770.3,
+      "end": 771,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Those",
+      "start": 771.1,
+      "end": 771.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 771.5,
+      "end": 771.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " probably",
+      "start": 771.6,
+      "end": 771.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 771.9,
+      "end": 772.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 772.1,
+      "end": 772.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 772.2,
+      "end": 772.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " split",
+      "start": 772.4,
+      "end": 772.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up",
+      "start": 772.7,
+      "end": 773,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 773.2,
+      "end": 773.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 773.6,
+      "end": 773.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder",
+      "start": 773.8,
+      "end": 774.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 774.2,
+      "end": 774.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 774.5,
+      "end": 774.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " departments",
+      "start": 774.9,
+      "end": 775.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 775.6,
+      "end": 776,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 776,
+      "end": 776.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 776.5,
+      "end": 776.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards",
+      "start": 776.8,
+      "end": 777.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 777.3,
+      "end": 777.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 777.4,
+      "end": 777.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " relevant",
+      "start": 777.5,
+      "end": 777.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 777.9,
+      "end": 778.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them.",
+      "start": 778.1,
+      "end": 778.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 778.8,
+      "end": 778.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " about",
+      "start": 779,
+      "end": 779.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 779.2,
+      "end": 779.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to-do",
+      "start": 779.6,
+      "end": 779.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists?",
+      "start": 779.9,
+      "end": 780.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Remember,",
+      "start": 780.4,
+      "end": 780.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 781,
+      "end": 781.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 781.3,
+      "end": 781.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 781.5,
+      "end": 781.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " don't",
+      "start": 781.6,
+      "end": 781.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 781.8,
+      "end": 781.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 782,
+      "end": 782,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " touch.",
+      "start": 782.1,
+      "end": 782.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Individual",
+      "start": 782.7,
+      "end": 783.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to-do",
+      "start": 783.2,
+      "end": 783.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists",
+      "start": 783.4,
+      "end": 783.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 783.7,
+      "end": 783.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " automatically",
+      "start": 784,
+      "end": 784.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " generated",
+      "start": 784.9,
+      "end": 785.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " by",
+      "start": 785.6,
+      "end": 785.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 785.9,
+      "end": 786.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 786.1,
+      "end": 786.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 786.3,
+      "end": 786.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 786.6,
+      "end": 786.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 786.7,
+      "end": 786.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " software,",
+      "start": 787.1,
+      "end": 787.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 787.5,
+      "end": 787.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 787.6,
+      "end": 787.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " shouldn't",
+      "start": 787.8,
+      "end": 788,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 788.1,
+      "end": 788.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 788.2,
+      "end": 788.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " touch",
+      "start": 788.3,
+      "end": 788.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that.",
+      "start": 788.5,
+      "end": 788.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Meeting",
+      "start": 789.3,
+      "end": 789.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " agendas,",
+      "start": 789.6,
+      "end": 790.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " again,",
+      "start": 790.2,
+      "end": 790.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 790.4,
+      "end": 790.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 790.5,
+      "end": 790.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 790.6,
+      "end": 790.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting",
+      "start": 790.8,
+      "end": 791,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " agendas",
+      "start": 791,
+      "end": 791.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " under",
+      "start": 791.4,
+      "end": 791.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operations",
+      "start": 791.6,
+      "end": 792.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 792.4,
+      "end": 792.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 792.6,
+      "end": 792.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 792.7,
+      "end": 792.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 792.8,
+      "end": 792.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 792.9,
+      "end": 793.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " underneath",
+      "start": 793.2,
+      "end": 793.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 793.7,
+      "end": 794,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 794,
+      "end": 794.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " department",
+      "start": 794.6,
+      "end": 795.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 795.1,
+      "end": 795.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 795.3,
+      "end": 795.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meetings",
+      "start": 795.4,
+      "end": 795.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 795.7,
+      "end": 795.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 795.8,
+      "end": 795.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " department",
+      "start": 796,
+      "end": 796.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " has?",
+      "start": 796.4,
+      "end": 796.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " No",
+      "start": 797.4,
+      "end": 797.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wrong",
+      "start": 797.7,
+      "end": 798,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " answers",
+      "start": 798,
+      "end": 798.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here.",
+      "start": 798.3,
+      "end": 798.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I'm",
+      "start": 798.8,
+      "end": 799,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " giving",
+      "start": 799,
+      "end": 799.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 799.2,
+      "end": 799.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 799.3,
+      "end": 799.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " suggestion,",
+      "start": 799.5,
+      "end": 800,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 800,
+      "end": 800.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 800.1,
+      "end": 800.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 800.3,
+      "end": 800.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " no",
+      "start": 800.6,
+      "end": 801,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wrong",
+      "start": 801.3,
+      "end": 801.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " answers",
+      "start": 801.8,
+      "end": 802.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here.",
+      "start": 802.4,
+      "end": 802.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 802.7,
+      "end": 803,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 803,
+      "end": 803.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 803.1,
+      "end": 803.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 803.3,
+      "end": 803.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 803.4,
+      "end": 803.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 803.6,
+      "end": 803.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " allow",
+      "start": 803.8,
+      "end": 804.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 804.3,
+      "end": 804.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 804.6,
+      "end": 805,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 805.3,
+      "end": 805.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 805.5,
+      "end": 805.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 805.6,
+      "end": 805.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organized",
+      "start": 805.9,
+      "end": 806.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 806.5,
+      "end": 806.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " functional",
+      "start": 806.7,
+      "end": 807.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 807.3,
+      "end": 807.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you.",
+      "start": 807.5,
+      "end": 807.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " You",
+      "start": 807.9,
+      "end": 808.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 808.1,
+      "end": 808.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 808.3,
+      "end": 808.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " decide.",
+      "start": 808.4,
+      "end": 808.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " You",
+      "start": 809,
+      "end": 809.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 809.2,
+      "end": 809.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 809.3,
+      "end": 809.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " customize",
+      "start": 809.4,
+      "end": 809.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this.",
+      "start": 809.9,
+      "end": 810.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 810.8,
+      "end": 810.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then",
+      "start": 811,
+      "end": 811.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lastly,",
+      "start": 811.1,
+      "end": 811.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project",
+      "start": 811.6,
+      "end": 811.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " management.",
+      "start": 811.9,
+      "end": 812.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 812.4,
+      "end": 812.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 812.6,
+      "end": 812.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " again",
+      "start": 812.7,
+      "end": 813.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " advise",
+      "start": 813.1,
+      "end": 813.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 813.8,
+      "end": 814.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 814.1,
+      "end": 814.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " projects",
+      "start": 814.5,
+      "end": 814.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " belong",
+      "start": 814.9,
+      "end": 815.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 815.3,
+      "end": 815.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 815.4,
+      "end": 815.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " departments",
+      "start": 815.7,
+      "end": 816.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 816.2,
+      "end": 816.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 816.3,
+      "end": 816.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " products.",
+      "start": 816.6,
+      "end": 817.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 817.3,
+      "end": 817.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 817.6,
+      "end": 817.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " major",
+      "start": 818,
+      "end": 818.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project",
+      "start": 818.5,
+      "end": 818.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " management",
+      "start": 818.9,
+      "end": 819.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " list",
+      "start": 819.5,
+      "end": 819.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 820,
+      "end": 820.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 820.3,
+      "end": 820.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 820.5,
+      "end": 820.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 820.7,
+      "end": 820.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " separated",
+      "start": 820.9,
+      "end": 821.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 821.5,
+      "end": 821.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 821.8,
+      "end": 821.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organized",
+      "start": 821.9,
+      "end": 822.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " accordingly.",
+      "start": 822.7,
+      "end": 823.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 823.9,
+      "end": 824.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 824.1,
+      "end": 824.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 824.4,
+      "end": 824.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 824.7,
+      "end": 824.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 824.9,
+      "end": 825,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " brain",
+      "start": 825,
+      "end": 825.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dump,",
+      "start": 825.2,
+      "end": 825.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 825.5,
+      "end": 825.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 825.7,
+      "end": 825.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 825.9,
+      "end": 826,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 826,
+      "end": 826.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " items,",
+      "start": 826.3,
+      "end": 826.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 826.6,
+      "end": 826.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 826.8,
+      "end": 826.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 826.9,
+      "end": 827,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 827,
+      "end": 827.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOPs,",
+      "start": 827.3,
+      "end": 827.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " everything",
+      "start": 827.9,
+      "end": 828.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 828.4,
+      "end": 828.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we've",
+      "start": 828.5,
+      "end": 828.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " listed",
+      "start": 828.7,
+      "end": 829.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 829.1,
+      "end": 829.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 829.7,
+      "end": 829.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 829.9,
+      "end": 830,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " categorize",
+      "start": 830.1,
+      "end": 830.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 830.8,
+      "end": 830.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organize",
+      "start": 831,
+      "end": 831.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 831.7,
+      "end": 832.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sub",
+      "start": 832.5,
+      "end": 832.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders",
+      "start": 833,
+      "end": 833.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 833.5,
+      "end": 833.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sub",
+      "start": 833.7,
+      "end": 834,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists",
+      "start": 834.1,
+      "end": 834.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " underneath",
+      "start": 835,
+      "end": 835.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 835.7,
+      "end": 836,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 836,
+      "end": 836.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 836.2,
+      "end": 836.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " departments.",
+      "start": 836.6,
+      "end": 837.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Gorgeous.",
+      "start": 837.6,
+      "end": 838.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 838.8,
+      "end": 838.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 838.9,
+      "end": 839,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 839,
+      "end": 839.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " scroll",
+      "start": 839.2,
+      "end": 839.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down",
+      "start": 839.5,
+      "end": 839.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 839.9,
+      "end": 840,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 840.1,
+      "end": 840.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " worksheet,",
+      "start": 840.2,
+      "end": 840.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 841,
+      "end": 841.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 841.2,
+      "end": 841.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " actually",
+      "start": 841.4,
+      "end": 841.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " given",
+      "start": 841.9,
+      "end": 842.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 842.2,
+      "end": 842.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " an",
+      "start": 842.5,
+      "end": 842.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 842.6,
+      "end": 843.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 843.4,
+      "end": 843.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 843.9,
+      "end": 844.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " personal",
+      "start": 844.6,
+      "end": 845.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 845.2,
+      "end": 845.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 845.5,
+      "end": 845.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 845.8,
+      "end": 845.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 845.9,
+      "end": 846.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 846.2,
+      "end": 846.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 846.4,
+      "end": 846.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 846.6,
+      "end": 846.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 846.7,
+      "end": 847,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 847.2,
+      "end": 847.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 847.4,
+      "end": 847.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 847.5,
+      "end": 847.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organized",
+      "start": 847.7,
+      "end": 848.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 848.2,
+      "end": 848.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 848.3,
+      "end": 848.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 848.4,
+      "end": 848.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 848.6,
+      "end": 848.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 848.9,
+      "end": 849.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ourselves.",
+      "start": 849.2,
+      "end": 849.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 850.5,
+      "end": 850.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 850.6,
+      "end": 850.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 850.7,
+      "end": 850.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 850.9,
+      "end": 851.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 851.3,
+      "end": 851.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 851.5,
+      "end": 851.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 851.8,
+      "end": 852.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 852.3,
+      "end": 852.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we're",
+      "start": 852.4,
+      "end": 852.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " talking",
+      "start": 852.6,
+      "end": 852.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " about",
+      "start": 852.9,
+      "end": 853.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right",
+      "start": 853.2,
+      "end": 853.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 853.3,
+      "end": 853.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 853.7,
+      "end": 854,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " literally",
+      "start": 854,
+      "end": 854.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 854.5,
+      "end": 854.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 854.7,
+      "end": 854.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 854.8,
+      "end": 855,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 855,
+      "end": 855.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 855.1,
+      "end": 855.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " appear",
+      "start": 855.2,
+      "end": 855.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " along",
+      "start": 855.8,
+      "end": 856.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 856.2,
+      "end": 856.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " left",
+      "start": 856.4,
+      "end": 856.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hand",
+      "start": 856.7,
+      "end": 856.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " side",
+      "start": 857,
+      "end": 857.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 857.7,
+      "end": 858,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 858,
+      "end": 858.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " click",
+      "start": 858.2,
+      "end": 858.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up",
+      "start": 858.4,
+      "end": 858.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " when",
+      "start": 858.6,
+      "end": 858.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 858.8,
+      "end": 858.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 858.9,
+      "end": 859,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 859,
+      "end": 859.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " build",
+      "start": 859.2,
+      "end": 859.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 859.3,
+      "end": 859.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 859.4,
+      "end": 859.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " or",
+      "start": 859.7,
+      "end": 859.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " whatever",
+      "start": 859.8,
+      "end": 860.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 860.6,
+      "end": 860.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 860.9,
+      "end": 861.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 861.1,
+      "end": 861.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 861.2,
+      "end": 861.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " software",
+      "start": 861.5,
+      "end": 861.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 861.9,
+      "end": 862,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " use.",
+      "start": 862.1,
+      "end": 862.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 863.2,
+      "end": 863.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I've",
+      "start": 863.4,
+      "end": 863.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " actually",
+      "start": 863.6,
+      "end": 863.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " labeled",
+      "start": 864,
+      "end": 864.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " where",
+      "start": 864.5,
+      "end": 864.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 864.9,
+      "end": 865.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 865.1,
+      "end": 865.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 865.2,
+      "end": 865.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " core",
+      "start": 865.4,
+      "end": 865.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pillars",
+      "start": 865.7,
+      "end": 866,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exist",
+      "start": 866.1,
+      "end": 866.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 866.8,
+      "end": 867.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 867.2,
+      "end": 867.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system.",
+      "start": 867.4,
+      "end": 867.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " The",
+      "start": 868.1,
+      "end": 868.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " individual",
+      "start": 868.3,
+      "end": 868.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to-do",
+      "start": 868.8,
+      "end": 869,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " list",
+      "start": 869,
+      "end": 869.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " function,",
+      "start": 869.2,
+      "end": 869.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " again,",
+      "start": 869.7,
+      "end": 869.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 869.9,
+      "end": 870.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 870.1,
+      "end": 870.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " built",
+      "start": 870.4,
+      "end": 870.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in.",
+      "start": 870.8,
+      "end": 871.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " That's",
+      "start": 871.2,
+      "end": 871.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 871.4,
+      "end": 871.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " home",
+      "start": 871.6,
+      "end": 871.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " function",
+      "start": 871.9,
+      "end": 872.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 872.6,
+      "end": 872.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ClickUp.",
+      "start": 873,
+      "end": 873.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " For",
+      "start": 873.7,
+      "end": 873.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 873.9,
+      "end": 874,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting",
+      "start": 874,
+      "end": 874.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " agendas,",
+      "start": 874.3,
+      "end": 874.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 874.8,
+      "end": 874.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " decided",
+      "start": 875,
+      "end": 875.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 875.3,
+      "end": 875.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " create",
+      "start": 875.4,
+      "end": 875.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting",
+      "start": 875.7,
+      "end": 876.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards.",
+      "start": 876.3,
+      "end": 877,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 877.2,
+      "end": 877.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 877.4,
+      "end": 877.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 877.7,
+      "end": 878,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting",
+      "start": 878,
+      "end": 878.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " has",
+      "start": 878.4,
+      "end": 878.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " its",
+      "start": 878.7,
+      "end": 878.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " own",
+      "start": 878.9,
+      "end": 879.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " unique",
+      "start": 879.3,
+      "end": 879.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboard",
+      "start": 879.7,
+      "end": 880.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 880.1,
+      "end": 880.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 880.2,
+      "end": 880.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " custom",
+      "start": 880.4,
+      "end": 880.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " built",
+      "start": 880.8,
+      "end": 881,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 881.1,
+      "end": 881.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 881.5,
+      "end": 881.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 881.8,
+      "end": 882,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting.",
+      "start": 882.1,
+      "end": 882.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Our",
+      "start": 882.9,
+      "end": 883.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 883.3,
+      "end": 883.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " warehouse",
+      "start": 883.7,
+      "end": 884.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 884.2,
+      "end": 884.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stored",
+      "start": 884.4,
+      "end": 884.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right",
+      "start": 884.8,
+      "end": 885,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here,",
+      "start": 885,
+      "end": 885.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOP",
+      "start": 885.3,
+      "end": 885.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " library.",
+      "start": 885.6,
+      "end": 886,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 886.2,
+      "end": 886.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stored",
+      "start": 886.4,
+      "end": 886.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 886.7,
+      "end": 886.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 886.9,
+      "end": 887,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operations",
+      "start": 887,
+      "end": 887.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder.",
+      "start": 887.6,
+      "end": 888,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 888.2,
+      "end": 888.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 888.3,
+      "end": 888.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 888.4,
+      "end": 888.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " scroll",
+      "start": 888.5,
+      "end": 888.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down,",
+      "start": 888.8,
+      "end": 889.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 889.1,
+      "end": 889.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 889.2,
+      "end": 889.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 889.3,
+      "end": 889.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 889.6,
+      "end": 889.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 889.9,
+      "end": 890.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 890.1,
+      "end": 890.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " many",
+      "start": 890.4,
+      "end": 890.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOPs",
+      "start": 891.1,
+      "end": 891.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organized",
+      "start": 892.1,
+      "end": 892.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " by",
+      "start": 893,
+      "end": 893.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " core",
+      "start": 893.3,
+      "end": 893.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " role,",
+      "start": 893.7,
+      "end": 894,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " core",
+      "start": 894,
+      "end": 894.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " department,",
+      "start": 894.2,
+      "end": 894.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " core",
+      "start": 894.7,
+      "end": 894.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " function.",
+      "start": 894.9,
+      "end": 895.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " You'll",
+      "start": 896.3,
+      "end": 896.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 896.5,
+      "end": 896.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project",
+      "start": 896.8,
+      "end": 897.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " management.",
+      "start": 897.1,
+      "end": 897.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 897.6,
+      "end": 897.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 897.7,
+      "end": 897.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 897.8,
+      "end": 898,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 898,
+      "end": 898.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project",
+      "start": 898.1,
+      "end": 898.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " called",
+      "start": 898.6,
+      "end": 898.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " DADA.",
+      "start": 898.9,
+      "end": 899.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Too",
+      "start": 900,
+      "end": 900.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " long",
+      "start": 900.2,
+      "end": 900.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 900.4,
+      "end": 900.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 900.5,
+      "end": 900.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 900.6,
+      "end": 900.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here,",
+      "start": 900.9,
+      "end": 901.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 901.1,
+      "end": 901.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 901.2,
+      "end": 901.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 901.3,
+      "end": 901.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 901.5,
+      "end": 901.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project",
+      "start": 901.5,
+      "end": 901.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " called",
+      "start": 901.9,
+      "end": 902.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Data.",
+      "start": 902.1,
+      "end": 902.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 902.8,
+      "end": 902.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 902.9,
+      "end": 903.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 903.1,
+      "end": 903.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " where",
+      "start": 903.2,
+      "end": 903.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 903.4,
+      "end": 903.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " managed",
+      "start": 903.5,
+      "end": 904.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 904.1,
+      "end": 904.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Data",
+      "start": 904.3,
+      "end": 904.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project.",
+      "start": 904.8,
+      "end": 905.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We",
+      "start": 905.7,
+      "end": 905.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 905.9,
+      "end": 906.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 906.1,
+      "end": 906.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards.",
+      "start": 906.5,
+      "end": 907,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " We",
+      "start": 907,
+      "end": 907.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 907.1,
+      "end": 907.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 907.2,
+      "end": 907.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 907.2,
+      "end": 907.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 907.5,
+      "end": 907.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tracker,",
+      "start": 907.8,
+      "end": 908.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 908.2,
+      "end": 908.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " retainer",
+      "start": 908.3,
+      "end": 908.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " client",
+      "start": 908.7,
+      "end": 909,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tracker.",
+      "start": 909,
+      "end": 909.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Those",
+      "start": 909.4,
+      "end": 909.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " two",
+      "start": 909.6,
+      "end": 909.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 909.8,
+      "end": 910,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 910,
+      "end": 910.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different,",
+      "start": 910.2,
+      "end": 910.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right?",
+      "start": 910.5,
+      "end": 910.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 911,
+      "end": 911.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 911.2,
+      "end": 911.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " had",
+      "start": 911.3,
+      "end": 911.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 911.6,
+      "end": 911.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 911.7,
+      "end": 912,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards",
+      "start": 912,
+      "end": 912.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 912.6,
+      "end": 912.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " were",
+      "start": 912.8,
+      "end": 912.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " scattered",
+      "start": 912.9,
+      "end": 913.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 913.5,
+      "end": 913.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 913.8,
+      "end": 914,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " way",
+      "start": 914,
+      "end": 914.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " through",
+      "start": 914.5,
+      "end": 914.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 914.9,
+      "end": 915.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 915.3,
+      "end": 915.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 915.5,
+      "end": 915.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " different",
+      "start": 915.8,
+      "end": 916.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders.",
+      "start": 916.1,
+      "end": 916.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " If",
+      "start": 916.6,
+      "end": 916.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 916.8,
+      "end": 916.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " really",
+      "start": 916.9,
+      "end": 917.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " expanded",
+      "start": 917.2,
+      "end": 917.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " every",
+      "start": 917.7,
+      "end": 918,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 918,
+      "end": 918.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 918.2,
+      "end": 918.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 918.4,
+      "end": 918.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 918.5,
+      "end": 918.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders,",
+      "start": 918.7,
+      "end": 919.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 919.4,
+      "end": 919.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " example",
+      "start": 919.6,
+      "end": 919.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " would",
+      "start": 920,
+      "end": 920.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 920.1,
+      "end": 920.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 920.3,
+      "end": 920.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 920.4,
+      "end": 920.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 920.6,
+      "end": 920.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " four",
+      "start": 920.8,
+      "end": 921,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pages.",
+      "start": 921,
+      "end": 921.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 921.8,
+      "end": 922,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 922,
+      "end": 922.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " tried",
+      "start": 922.1,
+      "end": 922.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 922.4,
+      "end": 922.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " keep",
+      "start": 922.5,
+      "end": 922.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 922.7,
+      "end": 922.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " short",
+      "start": 922.8,
+      "end": 923,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 923.1,
+      "end": 923.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sweet",
+      "start": 923.2,
+      "end": 923.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 923.4,
+      "end": 923.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 923.5,
+      "end": 923.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " guys.",
+      "start": 923.7,
+      "end": 924,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " But",
+      "start": 924.3,
+      "end": 924.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you'll",
+      "start": 924.4,
+      "end": 924.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 924.6,
+      "end": 924.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down",
+      "start": 924.8,
+      "end": 925,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here",
+      "start": 925.1,
+      "end": 925.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 925.6,
+      "end": 925.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 925.8,
+      "end": 926,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 926,
+      "end": 926.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " key",
+      "start": 926.5,
+      "end": 926.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders",
+      "start": 926.8,
+      "end": 927.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 927.5,
+      "end": 927.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 927.7,
+      "end": 928,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " key",
+      "start": 928,
+      "end": 928.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " department",
+      "start": 928.2,
+      "end": 928.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 928.8,
+      "end": 929,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " product",
+      "start": 929.1,
+      "end": 929.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 929.6,
+      "end": 930.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " our",
+      "start": 930.2,
+      "end": 930.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 930.4,
+      "end": 931,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " One",
+      "start": 931.5,
+      "end": 931.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " thing",
+      "start": 931.6,
+      "end": 931.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 931.8,
+      "end": 932,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 932,
+      "end": 932.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " really",
+      "start": 932.2,
+      "end": 932.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 932.4,
+      "end": 932.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 932.7,
+      "end": 932.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " an",
+      "start": 932.9,
+      "end": 932.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " executive",
+      "start": 933,
+      "end": 933.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folder,",
+      "start": 933.8,
+      "end": 934.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " which",
+      "start": 934.1,
+      "end": 934.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 934.3,
+      "end": 934.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 934.4,
+      "end": 934.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 934.5,
+      "end": 934.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 934.7,
+      "end": 934.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " little",
+      "start": 934.9,
+      "end": 935.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lock.",
+      "start": 935.1,
+      "end": 935.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " That",
+      "start": 935.5,
+      "end": 935.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " means",
+      "start": 935.7,
+      "end": 935.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 935.8,
+      "end": 936,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " private",
+      "start": 936,
+      "end": 936.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 936.4,
+      "end": 936.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 936.5,
+      "end": 936.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " where",
+      "start": 937,
+      "end": 937.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I'm",
+      "start": 937.2,
+      "end": 937.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " able",
+      "start": 937.4,
+      "end": 937.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 937.6,
+      "end": 937.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " track",
+      "start": 937.8,
+      "end": 938.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " executive",
+      "start": 938.1,
+      "end": 938.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " level",
+      "start": 938.7,
+      "end": 938.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " views",
+      "start": 939,
+      "end": 939.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 939.3,
+      "end": 939.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " visibility",
+      "start": 939.4,
+      "end": 940,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " across",
+      "start": 940,
+      "end": 940.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 940.5,
+      "end": 940.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 940.6,
+      "end": 941.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 941.3,
+      "end": 941.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " again,",
+      "start": 941.5,
+      "end": 941.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 941.9,
+      "end": 942.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 942.2,
+      "end": 942.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 942.4,
+      "end": 942.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " design",
+      "start": 942.6,
+      "end": 943.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 943.2,
+      "end": 943.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now.",
+      "start": 943.6,
+      "end": 943.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 944,
+      "end": 944.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 944.4,
+      "end": 944.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 944.5,
+      "end": 944.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " deliverable.",
+      "start": 944.7,
+      "end": 945.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 945.6,
+      "end": 945.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " overarching",
+      "start": 945.9,
+      "end": 946.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders",
+      "start": 946.7,
+      "end": 947.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 947.4,
+      "end": 947.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 947.6,
+      "end": 947.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want?",
+      "start": 947.8,
+      "end": 948.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 948.4,
+      "end": 948.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " master",
+      "start": 948.6,
+      "end": 949,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dashboards",
+      "start": 949.1,
+      "end": 949.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 949.5,
+      "end": 949.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " projects",
+      "start": 949.6,
+      "end": 950.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " belong",
+      "start": 950.4,
+      "end": 950.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 950.8,
+      "end": 951,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 951,
+      "end": 951.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 951.2,
+      "end": 951.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " those",
+      "start": 951.3,
+      "end": 951.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders?",
+      "start": 951.6,
+      "end": 952.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Where",
+      "start": 952.3,
+      "end": 952.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 952.5,
+      "end": 952.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 952.6,
+      "end": 952.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 952.8,
+      "end": 953,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 953,
+      "end": 953.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SOPs",
+      "start": 953.2,
+      "end": 953.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stored",
+      "start": 954.1,
+      "end": 954.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 954.6,
+      "end": 954.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " listed",
+      "start": 954.8,
+      "end": 955.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out?",
+      "start": 955.2,
+      "end": 955.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " How",
+      "start": 955.7,
+      "end": 955.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 955.9,
+      "end": 956,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 956,
+      "end": 956.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 956.2,
+      "end": 956.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 956.3,
+      "end": 956.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " structure",
+      "start": 956.4,
+      "end": 956.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 956.8,
+      "end": 957,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " meeting",
+      "start": 957,
+      "end": 957.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " agendas?",
+      "start": 957.3,
+      "end": 957.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " You",
+      "start": 958.1,
+      "end": 958.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 958.4,
+      "end": 958.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 958.6,
+      "end": 958.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " decide.",
+      "start": 958.8,
+      "end": 959.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 959.5,
+      "end": 959.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 959.7,
+      "end": 959.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you're",
+      "start": 959.8,
+      "end": 959.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " feeling",
+      "start": 959.9,
+      "end": 960.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 960.2,
+      "end": 960.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " little",
+      "start": 960.3,
+      "end": 960.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stuck",
+      "start": 960.5,
+      "end": 960.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " right",
+      "start": 960.8,
+      "end": 960.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now,",
+      "start": 960.9,
+      "end": 961.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like,",
+      "start": 961.1,
+      "end": 961.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " oh",
+      "start": 961.3,
+      "end": 961.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 961.4,
+      "end": 961.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " God,",
+      "start": 961.5,
+      "end": 961.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " John,",
+      "start": 961.7,
+      "end": 961.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 961.9,
+      "end": 961.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " way",
+      "start": 962,
+      "end": 962.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " too",
+      "start": 962.2,
+      "end": 962.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " much.",
+      "start": 962.3,
+      "end": 962.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 962.6,
+      "end": 962.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " don't",
+      "start": 962.7,
+      "end": 962.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " know",
+      "start": 962.8,
+      "end": 963,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 963,
+      "end": 963.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 963.2,
+      "end": 963.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 963.3,
+      "end": 963.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 963.5,
+      "end": 963.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organize",
+      "start": 963.6,
+      "end": 964,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this.",
+      "start": 964,
+      "end": 964.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " The",
+      "start": 964.6,
+      "end": 964.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " great",
+      "start": 964.8,
+      "end": 965.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " news",
+      "start": 965.1,
+      "end": 965.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 965.4,
+      "end": 965.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 965.9,
+      "end": 966.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 966.1,
+      "end": 966.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " always",
+      "start": 966.4,
+      "end": 967,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " change",
+      "start": 967.1,
+      "end": 967.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 967.5,
+      "end": 967.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " later.",
+      "start": 967.8,
+      "end": 968.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 968.6,
+      "end": 968.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 968.9,
+      "end": 969.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 969.1,
+      "end": 969.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 969.4,
+      "end": 969.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " give",
+      "start": 969.5,
+      "end": 969.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " an",
+      "start": 969.8,
+      "end": 970,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 970.1,
+      "end": 970.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 971,
+      "end": 971.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 971.1,
+      "end": 971.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 971.3,
+      "end": 971.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 971.6,
+      "end": 971.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 971.7,
+      "end": 971.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 971.8,
+      "end": 972.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 972.2,
+      "end": 972.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " something",
+      "start": 972.5,
+      "end": 972.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 972.8,
+      "end": 973,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 973,
+      "end": 973.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 973.4,
+      "end": 973.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of.",
+      "start": 973.6,
+      "end": 973.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " But",
+      "start": 974.1,
+      "end": 974.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " any",
+      "start": 974.2,
+      "end": 974.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 974.5,
+      "end": 974.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 974.7,
+      "end": 974.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 974.8,
+      "end": 975,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lists",
+      "start": 975.1,
+      "end": 975.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 975.7,
+      "end": 975.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 975.9,
+      "end": 976.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " reorganized",
+      "start": 976.1,
+      "end": 976.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " into",
+      "start": 976.9,
+      "end": 977.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " any",
+      "start": 977.1,
+      "end": 977.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 977.4,
+      "end": 977.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 977.6,
+      "end": 977.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " these",
+      "start": 977.7,
+      "end": 977.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " folders",
+      "start": 977.9,
+      "end": 978.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down",
+      "start": 978.5,
+      "end": 978.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 978.8,
+      "end": 978.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " road.",
+      "start": 978.9,
+      "end": 979.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 979.2,
+      "end": 979.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " frankly",
+      "start": 979.4,
+      "end": 979.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 980,
+      "end": 980.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 980.4,
+      "end": 980.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " irreversible.",
+      "start": 980.7,
+      "end": 981.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 981.6,
+      "end": 982,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 982,
+      "end": 982.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " invite",
+      "start": 982.3,
+      "end": 982.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 982.6,
+      "end": 982.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 983,
+      "end": 983.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " start.",
+      "start": 983.6,
+      "end": 984.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 984.6,
+      "end": 984.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " once",
+      "start": 984.8,
+      "end": 985,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 985,
+      "end": 985.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 985.1,
+      "end": 985.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 985.4,
+      "end": 985.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 985.6,
+      "end": 985.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 986,
+      "end": 986,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 986.1,
+      "end": 986.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " start",
+      "start": 986.2,
+      "end": 986.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " populating",
+      "start": 986.5,
+      "end": 987.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 987.2,
+      "end": 987.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 987.5,
+      "end": 987.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 987.7,
+      "end": 987.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " filling",
+      "start": 988,
+      "end": 988.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 988.3,
+      "end": 988.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in,",
+      "start": 988.6,
+      "end": 988.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you'll",
+      "start": 989.1,
+      "end": 989.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " figure",
+      "start": 989.4,
+      "end": 989.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 989.8,
+      "end": 990.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 990.3,
+      "end": 990.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " works",
+      "start": 990.6,
+      "end": 990.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " well",
+      "start": 990.9,
+      "end": 991.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 991.2,
+      "end": 991.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 991.4,
+      "end": 991.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 991.9,
+      "end": 992.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 992.1,
+      "end": 992.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 992.3,
+      "end": 992.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team.",
+      "start": 992.6,
+      "end": 992.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 993.2,
+      "end": 993.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 993.4,
+      "end": 993.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 993.8,
+      "end": 994.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 994.1,
+      "end": 994.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 994.2,
+      "end": 994.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " step",
+      "start": 994.3,
+      "end": 994.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " three",
+      "start": 994.6,
+      "end": 994.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 994.9,
+      "end": 995.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 995.1,
+      "end": 995.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process.",
+      "start": 995.3,
+      "end": 995.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 996.1,
+      "end": 996.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 996.3,
+      "end": 996.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 996.5,
+      "end": 996.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " once",
+      "start": 996.9,
+      "end": 997.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 997.1,
+      "end": 997.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 997.3,
+      "end": 997.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 997.5,
+      "end": 997.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " outline",
+      "start": 997.7,
+      "end": 998,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " completed.",
+      "start": 998,
+      "end": 998.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Give",
+      "start": 999.3,
+      "end": 999.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 999.6,
+      "end": 999.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 999.7,
+      "end": 999.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 999.9,
+      "end": 1000.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 1000.1,
+      "end": 1000.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1000.5,
+      "end": 1000.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " specifically",
+      "start": 1000.7,
+      "end": 1001.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " give",
+      "start": 1002.2,
+      "end": 1002.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1002.4,
+      "end": 1002.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1002.6,
+      "end": 1003,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1003.1,
+      "end": 1003.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operator.",
+      "start": 1003.9,
+      "end": 1004.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 1005,
+      "end": 1005.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 1005.2,
+      "end": 1005.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1005.4,
+      "end": 1005.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 1005.7,
+      "end": 1006.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1006.3,
+      "end": 1006.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operation",
+      "start": 1006.6,
+      "end": 1007.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " specialist",
+      "start": 1007.2,
+      "end": 1007.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 1007.8,
+      "end": 1008.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1008.3,
+      "end": 1008.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team,",
+      "start": 1008.8,
+      "end": 1009.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1009.4,
+      "end": 1009.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1009.8,
+      "end": 1010,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 1010.2,
+      "end": 1010.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project.",
+      "start": 1010.9,
+      "end": 1011.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 1011.9,
+      "end": 1012,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 1012,
+      "end": 1012.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1012.2,
+      "end": 1012.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " probably",
+      "start": 1012.2,
+      "end": 1012.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 1012.5,
+      "end": 1012.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 1012.8,
+      "end": 1012.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 1012.9,
+      "end": 1013,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1013.1,
+      "end": 1013.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " next",
+      "start": 1013.2,
+      "end": 1013.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " one",
+      "start": 1013.4,
+      "end": 1013.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1013.6,
+      "end": 1013.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " three",
+      "start": 1013.8,
+      "end": 1014.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " months",
+      "start": 1014.1,
+      "end": 1014.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1014.9,
+      "end": 1015.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " populate",
+      "start": 1015.1,
+      "end": 1015.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 1015.7,
+      "end": 1015.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1016,
+      "end": 1016.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1016.1,
+      "end": 1016.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 1016.2,
+      "end": 1016.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 1016.5,
+      "end": 1016.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1016.7,
+      "end": 1016.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1016.9,
+      "end": 1017.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want.",
+      "start": 1017.1,
+      "end": 1017.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " But",
+      "start": 1018.1,
+      "end": 1018.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " give",
+      "start": 1018.3,
+      "end": 1018.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1018.6,
+      "end": 1018.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1018.8,
+      "end": 1019,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1019.1,
+      "end": 1019.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operator.",
+      "start": 1019.3,
+      "end": 1019.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 1019.9,
+      "end": 1020.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1020.2,
+      "end": 1020.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 1020.6,
+      "end": 1021,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " skill",
+      "start": 1021.1,
+      "end": 1021.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " set.",
+      "start": 1021.5,
+      "end": 1021.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 1021.8,
+      "end": 1022,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1022,
+      "end": 1022.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 1022.2,
+      "end": 1022.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " job.",
+      "start": 1022.8,
+      "end": 1023.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 1023.2,
+      "end": 1023.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1023.4,
+      "end": 1023.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 1023.5,
+      "end": 1023.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " giving",
+      "start": 1023.7,
+      "end": 1024,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 1024,
+      "end": 1024.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " kid",
+      "start": 1024.1,
+      "end": 1024.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 1024.5,
+      "end": 1024.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " sandbox",
+      "start": 1024.7,
+      "end": 1025.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1025.6,
+      "end": 1025.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " play",
+      "start": 1025.8,
+      "end": 1026.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in.",
+      "start": 1026.1,
+      "end": 1026.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Like",
+      "start": 1026.3,
+      "end": 1026.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 1026.4,
+      "end": 1026.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1026.6,
+      "end": 1026.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1026.7,
+      "end": 1026.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " so",
+      "start": 1026.9,
+      "end": 1027.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " excited",
+      "start": 1027.5,
+      "end": 1028.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1028.3,
+      "end": 1028.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1028.5,
+      "end": 1028.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 1028.8,
+      "end": 1029.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 1029.2,
+      "end": 1029.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1029.7,
+      "end": 1029.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " redesign",
+      "start": 1030,
+      "end": 1030.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1030.5,
+      "end": 1030.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " build",
+      "start": 1030.7,
+      "end": 1030.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 1030.9,
+      "end": 1031.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 1031.1,
+      "end": 1031.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " company",
+      "start": 1031.2,
+      "end": 1031.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wide",
+      "start": 1031.5,
+      "end": 1031.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 1031.7,
+      "end": 1032,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 1032.1,
+      "end": 1032.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 1032.2,
+      "end": 1032.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can't",
+      "start": 1032.3,
+      "end": 1032.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wait.",
+      "start": 1032.6,
+      "end": 1032.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Right.",
+      "start": 1032.9,
+      "end": 1033.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 1033.3,
+      "end": 1033.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " give",
+      "start": 1033.7,
+      "end": 1034,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 1034,
+      "end": 1034.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1034.3,
+      "end": 1034.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " project,",
+      "start": 1034.6,
+      "end": 1035,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " set",
+      "start": 1035.1,
+      "end": 1035.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " realistic",
+      "start": 1035.4,
+      "end": 1036.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " timeline",
+      "start": 1036.1,
+      "end": 1036.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " expectations",
+      "start": 1036.6,
+      "end": 1037.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " with",
+      "start": 1037.3,
+      "end": 1037.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 1037.4,
+      "end": 1037.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " around",
+      "start": 1037.6,
+      "end": 1037.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 1037.8,
+      "end": 1038,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " long",
+      "start": 1038,
+      "end": 1038.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 1038.2,
+      "end": 1038.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 1038.4,
+      "end": 1038.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1038.5,
+      "end": 1038.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take.",
+      "start": 1038.6,
+      "end": 1038.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Again,",
+      "start": 1038.9,
+      "end": 1039.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1039.2,
+      "end": 1039.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " recommend",
+      "start": 1039.4,
+      "end": 1039.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " two",
+      "start": 1039.8,
+      "end": 1040,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1040.4,
+      "end": 1040.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " three",
+      "start": 1040.7,
+      "end": 1041,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " months",
+      "start": 1041.1,
+      "end": 1041.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " before",
+      "start": 1041.8,
+      "end": 1042,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1042.1,
+      "end": 1042.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1042.3,
+      "end": 1042.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fully",
+      "start": 1042.5,
+      "end": 1042.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " built",
+      "start": 1042.9,
+      "end": 1043.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1043.3,
+      "end": 1043.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " working",
+      "start": 1043.6,
+      "end": 1043.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 1043.9,
+      "end": 1044.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1044.2,
+      "end": 1044.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business",
+      "start": 1044.3,
+      "end": 1044.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1045,
+      "end": 1045.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " let",
+      "start": 1045.3,
+      "end": 1045.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them",
+      "start": 1045.6,
+      "end": 1046,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 1046,
+      "end": 1046.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 1046.3,
+      "end": 1046.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " magic.",
+      "start": 1046.7,
+      "end": 1047.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " You",
+      "start": 1047.5,
+      "end": 1047.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 1047.7,
+      "end": 1047.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 1047.9,
+      "end": 1048.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done",
+      "start": 1048.1,
+      "end": 1048.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1048.4,
+      "end": 1048.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " part.",
+      "start": 1048.6,
+      "end": 1048.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " You",
+      "start": 1048.9,
+      "end": 1049.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 1049.1,
+      "end": 1049.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " clear",
+      "start": 1049.3,
+      "end": 1049.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 1050,
+      "end": 1050.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 1050.2,
+      "end": 1050.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1050.4,
+      "end": 1050.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 1050.6,
+      "end": 1050.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " needs",
+      "start": 1051,
+      "end": 1051.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1051.2,
+      "end": 1051.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " include,",
+      "start": 1051.3,
+      "end": 1051.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 1051.9,
+      "end": 1052.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1052.3,
+      "end": 1052.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 1052.5,
+      "end": 1052.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1052.7,
+      "end": 1052.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " organized",
+      "start": 1052.9,
+      "end": 1053.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1053.6,
+      "end": 1053.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 1053.8,
+      "end": 1054.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1054.1,
+      "end": 1054.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " should",
+      "start": 1054.3,
+      "end": 1054.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " display.",
+      "start": 1054.6,
+      "end": 1055.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Now",
+      "start": 1055.7,
+      "end": 1056.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " let",
+      "start": 1056.2,
+      "end": 1056.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1056.5,
+      "end": 1056.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operator",
+      "start": 1056.7,
+      "end": 1057.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 1057.3,
+      "end": 1057.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1057.8,
+      "end": 1058,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work.",
+      "start": 1058.1,
+      "end": 1058.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " If",
+      "start": 1059.1,
+      "end": 1059.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1059.3,
+      "end": 1059.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " don't",
+      "start": 1059.5,
+      "end": 1059.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 1059.7,
+      "end": 1060.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " an",
+      "start": 1060.2,
+      "end": 1060.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operator,",
+      "start": 1060.5,
+      "end": 1061,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then",
+      "start": 1061.2,
+      "end": 1061.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 1061.4,
+      "end": 1061.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 1061.6,
+      "end": 1061.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 1061.8,
+      "end": 1061.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " kindness",
+      "start": 1061.9,
+      "end": 1062.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1062.5,
+      "end": 1062.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 1062.7,
+      "end": 1062.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " check",
+      "start": 1062.9,
+      "end": 1063.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 1063.2,
+      "end": 1063.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1063.4,
+      "end": 1063.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " other",
+      "start": 1063.6,
+      "end": 1063.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " live",
+      "start": 1063.8,
+      "end": 1064.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " masterclass",
+      "start": 1064.1,
+      "end": 1064.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1064.7,
+      "end": 1064.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1064.8,
+      "end": 1064.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " did",
+      "start": 1064.9,
+      "end": 1065.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 1065.1,
+      "end": 1065.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " SaaS",
+      "start": 1065.2,
+      "end": 1065.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Academy.",
+      "start": 1065.5,
+      "end": 1066,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It's",
+      "start": 1066.2,
+      "end": 1066.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " called",
+      "start": 1066.4,
+      "end": 1066.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1066.6,
+      "end": 1066.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " A-Player",
+      "start": 1066.9,
+      "end": 1067.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Operator",
+      "start": 1067.8,
+      "end": 1068.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Magnet.",
+      "start": 1068.5,
+      "end": 1069,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 1069.2,
+      "end": 1069.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1069.4,
+      "end": 1069.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " goes",
+      "start": 1069.5,
+      "end": 1069.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " through",
+      "start": 1069.8,
+      "end": 1069.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 1069.9,
+      "end": 1070.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " entire",
+      "start": 1070.1,
+      "end": 1070.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hiring",
+      "start": 1070.6,
+      "end": 1070.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process",
+      "start": 1070.9,
+      "end": 1071.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 1071.3,
+      "end": 1071.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " finding",
+      "start": 1071.6,
+      "end": 1072.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1072.1,
+      "end": 1072.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hiring",
+      "start": 1072.4,
+      "end": 1072.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1073.1,
+      "end": 1073.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operator.",
+      "start": 1073.5,
+      "end": 1074,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " One",
+      "start": 1074.3,
+      "end": 1074.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1074.4,
+      "end": 1074.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1074.5,
+      "end": 1074.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " biggest",
+      "start": 1074.7,
+      "end": 1075,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " questions",
+      "start": 1075,
+      "end": 1075.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1075.4,
+      "end": 1075.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " always",
+      "start": 1075.5,
+      "end": 1075.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 1075.7,
+      "end": 1075.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is,",
+      "start": 1075.9,
+      "end": 1076,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " well,",
+      "start": 1076,
+      "end": 1076.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 1076.2,
+      "end": 1076.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 1076.5,
+      "end": 1076.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1076.6,
+      "end": 1076.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hire",
+      "start": 1076.7,
+      "end": 1076.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " an",
+      "start": 1077,
+      "end": 1077,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ops",
+      "start": 1077.1,
+      "end": 1077.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " manager?",
+      "start": 1077.3,
+      "end": 1077.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " What",
+      "start": 1078,
+      "end": 1078.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 1078.1,
+      "end": 1078.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 1078.2,
+      "end": 1078.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 1078.3,
+      "end": 1078.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1078.5,
+      "end": 1078.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1078.5,
+      "end": 1078.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " doing?",
+      "start": 1078.7,
+      "end": 1079,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This.",
+      "start": 1080.2,
+      "end": 1080.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " They",
+      "start": 1081.1,
+      "end": 1081.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 1081.3,
+      "end": 1081.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 1081.4,
+      "end": 1081.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1081.6,
+      "end": 1081.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1081.8,
+      "end": 1081.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " building",
+      "start": 1082,
+      "end": 1082.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out,",
+      "start": 1082.4,
+      "end": 1082.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " designing,",
+      "start": 1082.9,
+      "end": 1083.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " optimizing,",
+      "start": 1083.6,
+      "end": 1084.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1084.3,
+      "end": 1084.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " continuously",
+      "start": 1084.5,
+      "end": 1085.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " updating",
+      "start": 1085.9,
+      "end": 1086.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1086.5,
+      "end": 1086.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " evolving",
+      "start": 1086.7,
+      "end": 1087.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1087.9,
+      "end": 1088.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " single",
+      "start": 1088.3,
+      "end": 1088.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " source",
+      "start": 1088.7,
+      "end": 1088.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1089,
+      "end": 1089.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " truth",
+      "start": 1089.1,
+      "end": 1089.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 1089.9,
+      "end": 1090.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1090.2,
+      "end": 1090.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " company",
+      "start": 1090.4,
+      "end": 1090.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " continues",
+      "start": 1090.7,
+      "end": 1091.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1091.2,
+      "end": 1091.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " grow",
+      "start": 1091.4,
+      "end": 1091.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1091.7,
+      "end": 1091.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " evolve.",
+      "start": 1091.8,
+      "end": 1092.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " This",
+      "start": 1092.3,
+      "end": 1092.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1092.7,
+      "end": 1092.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " their",
+      "start": 1093,
+      "end": 1093.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " baby.",
+      "start": 1093.7,
+      "end": 1094.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 1094.6,
+      "end": 1094.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 1094.8,
+      "end": 1095,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1095,
+      "end": 1095.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " recognize",
+      "start": 1095.2,
+      "end": 1095.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1095.8,
+      "end": 1095.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1096,
+      "end": 1096.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " company",
+      "start": 1096.1,
+      "end": 1096.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1096.5,
+      "end": 1096.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 1096.6,
+      "end": 1096.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1096.8,
+      "end": 1096.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " size",
+      "start": 1096.9,
+      "end": 1097.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1097.5,
+      "end": 1097.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1097.7,
+      "end": 1097.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " really",
+      "start": 1097.9,
+      "end": 1098.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " need",
+      "start": 1098.4,
+      "end": 1098.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 1099,
+      "end": 1099.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 1099.1,
+      "end": 1099.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " like",
+      "start": 1099.4,
+      "end": 1099.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this,",
+      "start": 1099.6,
+      "end": 1100,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1100.2,
+      "end": 1100.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1100.4,
+      "end": 1100.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " absolutely",
+      "start": 1100.8,
+      "end": 1101.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " do",
+      "start": 1101.7,
+      "end": 1102,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 1102,
+      "end": 1102.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 1102.3,
+      "end": 1102.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1102.5,
+      "end": 1102.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 1102.6,
+      "end": 1103,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1103.2,
+      "end": 1103.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 1103.4,
+      "end": 1103.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 1103.6,
+      "end": 1103.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1103.7,
+      "end": 1103.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " build",
+      "start": 1103.8,
+      "end": 1103.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1103.9,
+      "end": 1104,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " out",
+      "start": 1104,
+      "end": 1104.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " yourself,",
+      "start": 1104.2,
+      "end": 1104.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " then",
+      "start": 1104.9,
+      "end": 1105,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1105.1,
+      "end": 1105.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " might",
+      "start": 1105.2,
+      "end": 1105.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1105.4,
+      "end": 1105.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " a",
+      "start": 1105.5,
+      "end": 1105.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " good",
+      "start": 1105.6,
+      "end": 1105.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " indicator",
+      "start": 1105.8,
+      "end": 1106.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1106.3,
+      "end": 1106.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1106.5,
+      "end": 1106.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1106.6,
+      "end": 1106.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 1106.8,
+      "end": 1107.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 1107.1,
+      "end": 1107.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1107.2,
+      "end": 1107.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1107.3,
+      "end": 1107.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hire",
+      "start": 1107.4,
+      "end": 1107.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " an",
+      "start": 1107.8,
+      "end": 1107.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ops",
+      "start": 1107.9,
+      "end": 1108.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " manager.",
+      "start": 1108.2,
+      "end": 1108.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " So",
+      "start": 1108.8,
+      "end": 1109,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " again,",
+      "start": 1109,
+      "end": 1109.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " go",
+      "start": 1109.5,
+      "end": 1109.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " over,",
+      "start": 1109.7,
+      "end": 1109.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " check",
+      "start": 1110,
+      "end": 1110.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1110.2,
+      "end": 1110.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " A-player",
+      "start": 1110.4,
+      "end": 1110.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " operator",
+      "start": 1110.9,
+      "end": 1111.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " magnet",
+      "start": 1111.3,
+      "end": 1111.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 1111.7,
+      "end": 1111.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1111.8,
+      "end": 1111.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " want",
+      "start": 1111.9,
+      "end": 1112.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " my",
+      "start": 1112.1,
+      "end": 1112.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " blow-by-blow",
+      "start": 1112.3,
+      "end": 1112.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " on",
+      "start": 1113.2,
+      "end": 1113.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " exactly",
+      "start": 1113.3,
+      "end": 1113.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " who",
+      "start": 1113.7,
+      "end": 1113.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1113.9,
+      "end": 1114.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " person",
+      "start": 1114.1,
+      "end": 1114.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is,",
+      "start": 1114.4,
+      "end": 1114.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 1114.8,
+      "end": 1114.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " they",
+      "start": 1115,
+      "end": 1115.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " should",
+      "start": 1115.1,
+      "end": 1115.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1115.3,
+      "end": 1115.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " doing,",
+      "start": 1115.4,
+      "end": 1115.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 1115.7,
+      "end": 1115.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " much",
+      "start": 1115.9,
+      "end": 1116,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1116,
+      "end": 1116.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " pay",
+      "start": 1116.1,
+      "end": 1116.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them,",
+      "start": 1116.3,
+      "end": 1116.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " how",
+      "start": 1116.5,
+      "end": 1116.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1116.7,
+      "end": 1116.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hire",
+      "start": 1116.8,
+      "end": 1117,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " them,",
+      "start": 1117,
+      "end": 1117.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1117.4,
+      "end": 1117.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " works.",
+      "start": 1117.6,
+      "end": 1117.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It",
+      "start": 1117.9,
+      "end": 1118,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1118.1,
+      "end": 1118.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 1118.2,
+      "end": 1118.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " there",
+      "start": 1118.6,
+      "end": 1118.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 1119.1,
+      "end": 1119.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you.",
+      "start": 1119.3,
+      "end": 1119.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Okay,",
+      "start": 1120.4,
+      "end": 1120.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 1121.8,
+      "end": 1122.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 1122.1,
+      "end": 1122.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " here",
+      "start": 1122.4,
+      "end": 1122.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now.",
+      "start": 1122.7,
+      "end": 1122.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Congratulations.",
+      "start": 1123.2,
+      "end": 1124.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 1124.8,
+      "end": 1125.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1125.2,
+      "end": 1125.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1125.3,
+      "end": 1125.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " clear,",
+      "start": 1125.5,
+      "end": 1125.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1126.1,
+      "end": 1126.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 1126.4,
+      "end": 1126.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1126.7,
+      "end": 1126.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " just",
+      "start": 1126.9,
+      "end": 1127.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " beginning.",
+      "start": 1127.3,
+      "end": 1127.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Now",
+      "start": 1128.2,
+      "end": 1128.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " we",
+      "start": 1128.4,
+      "end": 1128.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " understand",
+      "start": 1128.5,
+      "end": 1128.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " what",
+      "start": 1128.9,
+      "end": 1129.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1129.1,
+      "end": 1129.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 1129.3,
+      "end": 1129.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is.",
+      "start": 1129.6,
+      "end": 1130,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It",
+      "start": 1130.2,
+      "end": 1130.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1130.4,
+      "end": 1130.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 1130.5,
+      "end": 1130.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1130.7,
+      "end": 1130.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " build",
+      "start": 1131,
+      "end": 1131.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1131.4,
+      "end": 1131.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " within",
+      "start": 1131.8,
+      "end": 1132.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1132.2,
+      "end": 1132.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " company.",
+      "start": 1132.3,
+      "end": 1132.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It",
+      "start": 1132.8,
+      "end": 1132.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1133,
+      "end": 1133.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 1133.1,
+      "end": 1133.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1133.3,
+      "end": 1133.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " use",
+      "start": 1133.7,
+      "end": 1134,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1134,
+      "end": 1134.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " across",
+      "start": 1134.6,
+      "end": 1135,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1135,
+      "end": 1135.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1135.3,
+      "end": 1135.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1135.5,
+      "end": 1135.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team.",
+      "start": 1135.7,
+      "end": 1136,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 1136.4,
+      "end": 1136.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1136.5,
+      "end": 1136.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " promise",
+      "start": 1136.7,
+      "end": 1137.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1137.2,
+      "end": 1137.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1137.5,
+      "end": 1137.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 1137.6,
+      "end": 1137.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1137.7,
+      "end": 1137.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " commit",
+      "start": 1137.9,
+      "end": 1138.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1138.6,
+      "end": 1139,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1139,
+      "end": 1139.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process,",
+      "start": 1139.3,
+      "end": 1139.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " because",
+      "start": 1139.8,
+      "end": 1140,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 1140,
+      "end": 1140.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 1140.2,
+      "end": 1140.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 1140.3,
+      "end": 1140.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1140.4,
+      "end": 1140.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1140.5,
+      "end": 1140.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " easy,",
+      "start": 1140.6,
+      "end": 1141,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it's",
+      "start": 1141.3,
+      "end": 1141.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " going",
+      "start": 1141.4,
+      "end": 1141.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1141.6,
+      "end": 1141.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " take",
+      "start": 1141.7,
+      "end": 1141.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time.",
+      "start": 1141.9,
+      "end": 1142.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " But",
+      "start": 1142.6,
+      "end": 1142.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " if",
+      "start": 1142.8,
+      "end": 1142.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1143,
+      "end": 1143.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " commit",
+      "start": 1143.1,
+      "end": 1143.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1143.5,
+      "end": 1143.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it,",
+      "start": 1143.7,
+      "end": 1143.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1144.2,
+      "end": 1144.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1144.4,
+      "end": 1144.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " fundamentally",
+      "start": 1144.9,
+      "end": 1146.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " transform",
+      "start": 1146.8,
+      "end": 1147.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1148,
+      "end": 1148.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " day-to-day",
+      "start": 1148.2,
+      "end": 1148.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1149,
+      "end": 1149.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1149.2,
+      "end": 1149.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 1149.5,
+      "end": 1149.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " It",
+      "start": 1150.2,
+      "end": 1150.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1150.4,
+      "end": 1150.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 1150.6,
+      "end": 1150.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " only",
+      "start": 1150.9,
+      "end": 1151.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " radically",
+      "start": 1151.4,
+      "end": 1152,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " improve",
+      "start": 1152.1,
+      "end": 1152.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1153.1,
+      "end": 1153.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " productivity",
+      "start": 1153.2,
+      "end": 1154,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1154,
+      "end": 1154.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1154.3,
+      "end": 1154.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team,",
+      "start": 1154.5,
+      "end": 1154.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1155.2,
+      "end": 1155.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1155.4,
+      "end": 1155.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 1155.5,
+      "end": 1155.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " only",
+      "start": 1155.8,
+      "end": 1156,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " massively",
+      "start": 1156.3,
+      "end": 1157,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " speed",
+      "start": 1157.2,
+      "end": 1157.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up",
+      "start": 1157.6,
+      "end": 1157.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1158.2,
+      "end": 1158.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team's",
+      "start": 1158.4,
+      "end": 1158.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " execution",
+      "start": 1158.8,
+      "end": 1159.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1159.5,
+      "end": 1159.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ability",
+      "start": 1159.7,
+      "end": 1160.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1160.2,
+      "end": 1160.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 1160.4,
+      "end": 1160.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " work",
+      "start": 1160.7,
+      "end": 1160.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " done,",
+      "start": 1161.1,
+      "end": 1161.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1161.8,
+      "end": 1161.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1161.9,
+      "end": 1162.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " not",
+      "start": 1162.1,
+      "end": 1162.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " only",
+      "start": 1162.4,
+      "end": 1162.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " ensure",
+      "start": 1163.1,
+      "end": 1163.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1163.6,
+      "end": 1163.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1163.7,
+      "end": 1163.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 1163.9,
+      "end": 1164,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " able",
+      "start": 1164,
+      "end": 1164.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1164.3,
+      "end": 1164.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " scale",
+      "start": 1164.5,
+      "end": 1164.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 1164.9,
+      "end": 1165.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " maximum",
+      "start": 1165.2,
+      "end": 1165.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " profitability",
+      "start": 1166.1,
+      "end": 1167.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1167.6,
+      "end": 1167.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " keep",
+      "start": 1167.9,
+      "end": 1168.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1168.2,
+      "end": 1168.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " team",
+      "start": 1168.3,
+      "end": 1168.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 1168.7,
+      "end": 1168.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " small",
+      "start": 1168.9,
+      "end": 1169.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1169.4,
+      "end": 1169.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " lean",
+      "start": 1169.6,
+      "end": 1169.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " as",
+      "start": 1169.9,
+      "end": 1170,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " possible",
+      "start": 1170,
+      "end": 1170.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at",
+      "start": 1170.5,
+      "end": 1170.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " each",
+      "start": 1170.7,
+      "end": 1170.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stage",
+      "start": 1170.9,
+      "end": 1171.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1171.2,
+      "end": 1171.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " growth,",
+      "start": 1171.4,
+      "end": 1171.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " but",
+      "start": 1172.1,
+      "end": 1172.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " it",
+      "start": 1172.3,
+      "end": 1172.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1172.5,
+      "end": 1172.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " also",
+      "start": 1173,
+      "end": 1173.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " vastly",
+      "start": 1174.2,
+      "end": 1174.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " improve",
+      "start": 1174.8,
+      "end": 1175.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1175.5,
+      "end": 1175.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " day-to-day",
+      "start": 1175.7,
+      "end": 1176.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " experience",
+      "start": 1176.3,
+      "end": 1176.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1176.9,
+      "end": 1177,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1177.1,
+      "end": 1177.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " have",
+      "start": 1177.3,
+      "end": 1177.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1177.8,
+      "end": 1178.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " running",
+      "start": 1178.1,
+      "end": 1178.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1178.4,
+      "end": 1178.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 1178.6,
+      "end": 1179,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Because",
+      "start": 1179.3,
+      "end": 1179.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " now",
+      "start": 1179.6,
+      "end": 1179.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 1179.9,
+      "end": 1180.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1180.3,
+      "end": 1180.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1180.4,
+      "end": 1180.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " time",
+      "start": 1180.6,
+      "end": 1180.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1180.9,
+      "end": 1181,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " energy",
+      "start": 1181,
+      "end": 1181.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1181.4,
+      "end": 1181.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " be",
+      "start": 1181.6,
+      "end": 1181.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " freed",
+      "start": 1181.7,
+      "end": 1182.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " up",
+      "start": 1182.1,
+      "end": 1182.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " from",
+      "start": 1182.7,
+      "end": 1182.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1182.9,
+      "end": 1183,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " dropped",
+      "start": 1183,
+      "end": 1183.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " balls",
+      "start": 1183.4,
+      "end": 1183.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1183.9,
+      "end": 1184.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1184.1,
+      "end": 1184.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " micro",
+      "start": 1184.2,
+      "end": 1184.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " detail",
+      "start": 1184.5,
+      "end": 1184.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1185,
+      "end": 1185.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " being",
+      "start": 1185.1,
+      "end": 1185.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " down",
+      "start": 1185.4,
+      "end": 1185.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " stuck",
+      "start": 1185.8,
+      "end": 1186.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 1186.2,
+      "end": 1186.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1186.4,
+      "end": 1186.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " weeds",
+      "start": 1186.5,
+      "end": 1186.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1186.8,
+      "end": 1187,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1187,
+      "end": 1187.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business.",
+      "start": 1187.3,
+      "end": 1187.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 1188.3,
+      "end": 1188.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1188.5,
+      "end": 1188.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " can",
+      "start": 1188.6,
+      "end": 1188.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " hand",
+      "start": 1188.9,
+      "end": 1189.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " all",
+      "start": 1189.4,
+      "end": 1189.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1189.7,
+      "end": 1189.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1189.8,
+      "end": 1190,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " off",
+      "start": 1190.1,
+      "end": 1190.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1190.5,
+      "end": 1190.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1190.6,
+      "end": 1190.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system",
+      "start": 1190.9,
+      "end": 1191.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " itself",
+      "start": 1191.4,
+      "end": 1192,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1192.6,
+      "end": 1192.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " get",
+      "start": 1192.8,
+      "end": 1193,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " back",
+      "start": 1193.2,
+      "end": 1193.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1193.5,
+      "end": 1193.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " doing",
+      "start": 1194.1,
+      "end": 1194.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1194.3,
+      "end": 1194.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 1194.4,
+      "end": 1194.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1194.7,
+      "end": 1194.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " love",
+      "start": 1194.9,
+      "end": 1195.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1195.2,
+      "end": 1195.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " most,",
+      "start": 1195.3,
+      "end": 1195.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " doing",
+      "start": 1195.9,
+      "end": 1196.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1196.1,
+      "end": 1196.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 1196.2,
+      "end": 1196.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1196.4,
+      "end": 1196.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " are",
+      "start": 1196.6,
+      "end": 1196.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " best",
+      "start": 1196.8,
+      "end": 1197.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " at,",
+      "start": 1197.2,
+      "end": 1197.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " and",
+      "start": 1197.7,
+      "end": 1197.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " doing",
+      "start": 1197.8,
+      "end": 1198.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1198.1,
+      "end": 1198.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " things",
+      "start": 1198.3,
+      "end": 1198.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " that",
+      "start": 1198.6,
+      "end": 1198.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " drive",
+      "start": 1198.8,
+      "end": 1199,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " real",
+      "start": 1199.3,
+      "end": 1199.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " value",
+      "start": 1200.1,
+      "end": 1200.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1201,
+      "end": 1201.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1201.5,
+      "end": 1201.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " company.",
+      "start": 1202,
+      "end": 1202.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1202.7,
+      "end": 1202.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " cannot",
+      "start": 1203.3,
+      "end": 1203.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wait",
+      "start": 1204.2,
+      "end": 1204.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1205.1,
+      "end": 1205.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 1205.4,
+      "end": 1205.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " your",
+      "start": 1205.6,
+      "end": 1205.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " business",
+      "start": 1205.9,
+      "end": 1206.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " transformed",
+      "start": 1206.3,
+      "end": 1207.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " by",
+      "start": 1207.5,
+      "end": 1207.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1207.9,
+      "end": 1208.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " system.",
+      "start": 1208.2,
+      "end": 1208.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 1208.6,
+      "end": 1208.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1208.8,
+      "end": 1208.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " cannot",
+      "start": 1208.9,
+      "end": 1209.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " wait",
+      "start": 1209.3,
+      "end": 1209.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " to",
+      "start": 1210,
+      "end": 1210.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " support",
+      "start": 1210.3,
+      "end": 1210.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1210.8,
+      "end": 1211,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " in",
+      "start": 1211.3,
+      "end": 1211.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " the",
+      "start": 1211.6,
+      "end": 1211.7,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " next",
+      "start": 1211.7,
+      "end": 1212,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " steps",
+      "start": 1212.1,
+      "end": 1212.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " of",
+      "start": 1212.5,
+      "end": 1212.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1213,
+      "end": 1213.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " journey.",
+      "start": 1213.5,
+      "end": 1213.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " My",
+      "start": 1214.3,
+      "end": 1214.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " name",
+      "start": 1214.6,
+      "end": 1214.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " is",
+      "start": 1214.8,
+      "end": 1215,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Jonna",
+      "start": 1215,
+      "end": 1215.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " Lee.",
+      "start": 1215.3,
+      "end": 1215.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " A",
+      "start": 1215.9,
+      "end": 1215.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " massive",
+      "start": 1216.1,
+      "end": 1216.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " thank",
+      "start": 1216.7,
+      "end": 1216.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1216.9,
+      "end": 1217.1,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " for",
+      "start": 1217.3,
+      "end": 1217.5,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " letting",
+      "start": 1217.5,
+      "end": 1217.8,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " me",
+      "start": 1217.9,
+      "end": 1218,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " guide",
+      "start": 1218,
+      "end": 1218.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1218.2,
+      "end": 1218.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " through",
+      "start": 1218.4,
+      "end": 1218.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " this",
+      "start": 1218.7,
+      "end": 1218.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " process.",
+      "start": 1218.9,
+      "end": 1219.4,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " And",
+      "start": 1219.7,
+      "end": 1219.9,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " I",
+      "start": 1219.9,
+      "end": 1220,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " will",
+      "start": 1220,
+      "end": 1220.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " see",
+      "start": 1220.2,
+      "end": 1220.3,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " you",
+      "start": 1220.4,
+      "end": 1220.6,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " very",
+      "start": 1220.9,
+      "end": 1221.2,
+      "type": "transcription_segment"
+    },
+    {
+      "text": " soon.",
+      "start": 1221.2,
+      "end": 1221.5,
+      "type": "transcription_segment"
+    }
+  ],
+  "usage": {
+    "promptTokens": 20,
+    "completionTokens": 32798,
+    "totalTokens": 32818,
+    "promptAudioSeconds": 1225,
+    "additionalProperties": {
+      "request_count": 5,
+      "num_cached_tokens": 0
+    }
+  },
+  "language": null,
+  "additionalProperties": {
+    "type": "transcription.done"
+  }
+}


### PR DESCRIPTION
## Summary

- Fix Mistral converter to handle real Voxtral API output (not just synthetic test fixture)
- Support diarized format: `speaker_id` field, sentence-level segments, no nested `words`
- Support word-level format: individual word segments with no speaker info
- Auto-detect format from first segment's structure
- Group word-level segments into utterances by punctuation, pause gaps, or max length
- Create synthetic word entries for diarized segments so WebVTT generation works
- Trim leading whitespace from Mistral segment text

## Problem

The converter was built from a synthetic fixture using `"speaker"` and nested `"words"` arrays. The real Voxtral API uses `"speaker_id"` and has no nested words, producing either sentence-level segments (with diarization) or word-level segments (without). This caused:
- All speakers resolving to `null`
- All `words` arrays being empty `[]`
- WebVTT files being completely empty

## Test plan

- [x] All 11 existing legacy format tests pass (backwards compatible)
- [x] 4 new diarized format tests (speaker_id mapping, synthetic words, WebVTT, text trimming)
- [x] 6 new word-level format tests (grouping by punctuation, pause, WebVTT, trimming, int coercion)
- [x] Full suite: 29 doctests + 73 tests, 0 failures
- [x] `mix format --check-formatted` passes