### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-02-06
+
+### Fixed
+- Mistral converter now handles real Voxtral API output formats (previously only worked with synthetic test data)
+- Support for diarized mode: `speaker_id` field, sentence-level segments without nested `words`
+- Support for word-level mode: individual word segments grouped into utterances by punctuation, pauses, or length
+- Leading whitespace in Mistral segment text is now trimmed
+- WebVTT generation no longer produces empty files for Mistral transcripts
+
 ## [0.8.0] - 2026-02-06
 
 ### Added
@@ -55,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For releases before 0.6.0, see the [git history](https://github.com/boldvideo/transcripts_ex/commits/main).
 
+[0.8.1]: https://github.com/boldvideo/transcripts_ex/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/boldvideo/transcripts_ex/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/boldvideo/transcripts_ex/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/boldvideo/transcripts_ex/compare/v0.5.1...v0.6.0

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BoldTranscriptsEx.MixProject do
   def project do
     [
       app: :bold_transcripts_ex,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary

Patch release to fix the Mistral Voxtral converter for real API output.

- Bumps version to 0.8.1
- Updates CHANGELOG with fix details

## What's in 0.8.1

**Fixed**: Mistral converter now handles the two real Voxtral API output formats:
- **Diarized mode** (`speaker_id`, sentence-level segments, no nested `words`)
- **Word-level mode** (individual word segments, no speaker info)

Previously the converter only worked with a synthetic test fixture format, producing empty `words` arrays and empty VTT files for real transcripts.

## Release steps

1. Merge this PR
2. Create GitHub Release tagged `v0.8.1` → auto-publishes to hex.pm